### PR TITLE
feat(infra): add claude-code-oauth-token and langsmith-api-key secrets

### DIFF
--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -8,4 +8,8 @@ config:
   bartools:memory: 512Mi
   bartools:databaseUrl:
     secure: v1:ZlY3vNNqk33w8q+V:K+xa4ZklTU4G5oo/CdTl9NkFswhQOfJQTQGhnPXnBZwbSEBKFVsR8G9hSWDsHEdgRMcbG8rXejBoA3lBM/YKNZ3RJ8q6p0jYAI5RLr6YB7SV7pEn3x3DrwoW6s6YH1VqchA2u3SZ/yN6QSwbYQVnVOJ4IPEzAy/gB9gX6lQdajeUEp24zHCzWHfD6H3ZyX2mgMXOGSn5AHLbHTNvk4dMmVf3Ww==
+  bartools:claudeCodeOauthToken:
+    secure: v1:Flc+xenFzYRxwmng:eg8Bem/mxFnGMzTcEEeyeN3INr64K2G8JZBny/Q5YzkeHkcJr/jr46OM2OKkDKdHWdv7Z6d4z92GKJf6yCKUWqf6CWgLbVIrtZwbzbcJ35oJcw6eKuW4+jdQcqP7hXd4A0BblZ5OCFHo9EM0QQrmOucwbyeG5jQJGu9czw==
+  bartools:langsmithApiKey:
+    secure: v1:Tw8TUxtj/AmSLngV:AXy9pW6eQhWqBpQKwlSeTpmHV+LjUQNLwvvML42igYjKsvWhh85YqsFMAc+hvxyrq5WfxGO/G3SpPE+aoo4ak+VJJA==
 encryptionsalt: v1:PP6V2+xP1hA=:v1:9U5fn0Tpw+2hWD1l:/dzKsBHnweZuDXwxhED0GSbaSNx3pw==

--- a/infra/Pulumi.staging.yaml
+++ b/infra/Pulumi.staging.yaml
@@ -8,4 +8,8 @@ config:
   bartools:memory: 512Mi
   bartools:databaseUrl:
     secure: v1:GufiGGvqP4dCATO+:R064hj1ZDZdQBV6J9PCHZm1kioJuGzXEjpoXiUQxxxowH3tU3YZxntTkAaUHqPXr23GN3XlBIA49omRiREX6RCdT7AxbMsnwxKGXyVjf4hrY+8ahKj95ps/vn3SRKTSX4kuhhuF37UP25DQWn/Ev1/YMqKJ8TErv7W9hFWSuierNgVDW6KR+9UKXMa4fmxXBY7IT98Z3DBfdNHsO+w4PdDDRFLY=
+  bartools:claudeCodeOauthToken:
+    secure: v1:RfhU50fn1lllCkQm:No1u6bDOFC95McmDN+0V5Np26XaiZiA+on3/G0tIY6puUZ2yyaH875FYiDRaGxyvhH4HnpFETRgT5ZTuFMAjVHKpkTkDBI/XSV0CcSnp9azqI77kXFRE8g4FRguCCjBSEkpRXzpXieys63MfYPalEeDST5DoomnPivIjGA==
+  bartools:langsmithApiKey:
+    secure: v1:/uv5WDC72TSHlseR:f5EzNx1AITbNIanPXqzAlNPnUoDbilMaa95P5Y50YT5YRMxuhJd1W7FzCOMXc7+t+YKnLAOXcrk2DK0FtlgnJEtQPg==
 encryptionsalt: v1:mSpTjxC1/UQ=:v1:rSnlWSg3quqxuZbk:F1mpag5lqxqNKuzdTJ2E2CZqvH1deA==


### PR DESCRIPTION
## Summary

Adds ciphertext for two new Pulumi config secrets per stack. The shared-foundation base PR already generalized `createDatabaseUrlSecret` → `createBackendSecret` and wired both call-sites in `infra/index.ts` + env delivery in `run.ts`. This PR just supplies the secret values.

**Base:** `chore/shared-foundation` (stacked). Re-targets `main` automatically once that merges.

## Test plan

- [ ] `pulumi -C infra preview --stack staging` shows two new `secretmanager.Secret` + `SecretVersion` + `SecretIamMember` tuples and two new env entries on the Cloud Run service
- [ ] After `pulumi up --stack staging`: backend Cloud Run revision boots with both new envs present