### PR TITLE
Add staging TestFlight track for mobile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,6 +99,7 @@
         "expo-constants": "~18.0.13",
         "expo-dev-client": "~6.0.20",
         "expo-file-system": "~19.0.21",
+        "expo-font": "~14.0.11",
         "expo-image-picker": "~17.0.10",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
@@ -112,6 +113,7 @@
         "react-native-screens": "~4.16.0",
         "react-native-sse": "^1.2.1",
         "react-native-vision-camera": "^4.7.3",
+        "react-native-worklets": "^0.8.0",
         "react-native-worklets-core": "^1.6.3",
       },
       "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -142,6 +142,9 @@
       },
     },
   },
+  "trustedDependencies": [
+    "@shopify/react-native-skia",
+  ],
   "overrides": {
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+linker = "hoisted"

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "overrides": {
     "react": "19.1.0",
     "react-dom": "19.1.0"
-  }
+  },
+  "trustedDependencies": [
+    "@shopify/react-native-skia"
+  ]
 }

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -8,9 +8,9 @@ const PROD_BUNDLE_ID = 'com.bartools.barback'
 
 export default ({ config }: { config: Record<string, unknown> }) => ({
   ...config,
-  name: IS_STAGING ? 'BarBack (Staging)' : config.name ?? 'BarBack',
+  name: IS_STAGING ? 'BarTools (Staging)' : config.name ?? 'BarTools',
   slug: config.slug ?? 'barback',
-  scheme: IS_STAGING ? 'barback-staging' : config.scheme ?? 'barback',
+  scheme: IS_STAGING ? 'bartools-staging' : config.scheme ?? 'bartools',
   ios: {
     ...(config.ios as Record<string, unknown>),
     bundleIdentifier: IS_STAGING ? STAGING_BUNDLE_ID : PROD_BUNDLE_ID,

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -1,0 +1,22 @@
+// Env-switched Expo config. Reads app.json as the base, overlays variant-specific
+// fields. Set APP_VARIANT=staging (via EAS env) to build the staging variant.
+
+const IS_STAGING = process.env.APP_VARIANT === 'staging'
+
+const STAGING_BUNDLE_ID = 'com.bartools.barback.staging'
+const PROD_BUNDLE_ID = 'com.bartools.barback'
+
+export default ({ config }: { config: Record<string, unknown> }) => ({
+  ...config,
+  name: IS_STAGING ? 'BarBack (Staging)' : config.name ?? 'BarBack',
+  slug: config.slug ?? 'barback',
+  scheme: IS_STAGING ? 'barback-staging' : config.scheme ?? 'barback',
+  ios: {
+    ...(config.ios as Record<string, unknown>),
+    bundleIdentifier: IS_STAGING ? STAGING_BUNDLE_ID : PROD_BUNDLE_ID,
+  },
+  android: {
+    ...(config.android as Record<string, unknown>),
+    package: IS_STAGING ? STAGING_BUNDLE_ID : PROD_BUNDLE_ID,
+  },
+})

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -1,9 +1,9 @@
 {
   "expo": {
-    "name": "BarBack",
+    "name": "BarTools",
     "slug": "barback",
     "owner": "ray.ockenfels",
-    "scheme": "barback",
+    "scheme": "bartools",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -28,7 +28,7 @@
         "NSMicrophoneUsageDescription": "BarBack does not record audio. This key is required by the camera framework used to photograph bottles.",
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "6"
+      "buildNumber": "8"
     },
     "android": {
       "package": "com.bartools.barback",

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -24,7 +24,8 @@
       "infoPlist": {
         "NSCameraUsageDescription": "BarBack uses the camera to photograph bottles for inventory identification.",
         "NSPhotoLibraryUsageDescription": "BarBack accesses your photo library to import bottle photos for inventory."
-      }
+      },
+      "buildNumber": "4"
     },
     "android": {
       "package": "com.bartools.barback",
@@ -36,17 +37,26 @@
       "predictiveBackGestureEnabled": false,
       "permissions": [
         "android.permission.CAMERA"
-      ]
+      ],
+      "versionCode": 4
     },
     "web": {
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
-      ["expo-build-properties", {
-        "ios": { "newArchEnabled": true },
-        "android": { "newArchEnabled": true }
-      }],
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "newArchEnabled": true
+          },
+          "android": {
+            "newArchEnabled": true
+          }
+        }
+      ],
       "expo-router",
+      "expo-font",
       [
         "react-native-vision-camera",
         {

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -22,13 +22,13 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.bartools.barback",
       "infoPlist": {
-        "NSCameraUsageDescription": "BarBack uses the camera to photograph bottles for inventory identification.",
-        "NSPhotoLibraryUsageDescription": "BarBack accesses your photo library to import bottle photos for inventory.",
-        "NSLocationWhenInUseUsageDescription": "BarBack does not use your location. This key is required because a bundled dependency references the Location API.",
-        "NSMicrophoneUsageDescription": "BarBack does not record audio. This key is required by the camera framework used to photograph bottles.",
+        "NSCameraUsageDescription": "BarTools uses the camera to photograph bottles for inventory identification.",
+        "NSPhotoLibraryUsageDescription": "BarTools accesses your photo library to import bottle photos for inventory.",
+        "NSLocationWhenInUseUsageDescription": "BarTools does not use your location. This key is required because a bundled dependency references the Location API.",
+        "NSMicrophoneUsageDescription": "BarTools does not record audio. This key is required by the camera framework used to photograph bottles.",
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "8"
+      "buildNumber": "10"
     },
     "android": {
       "package": "com.bartools.barback",
@@ -63,14 +63,14 @@
       [
         "react-native-vision-camera",
         {
-          "cameraPermissionText": "BarBack uses the camera to photograph bottles for inventory identification.",
+          "cameraPermissionText": "BarTools uses the camera to photograph bottles for inventory identification.",
           "enableMicrophonePermission": false
         }
       ],
       [
         "expo-image-picker",
         {
-          "photosPermission": "BarBack accesses your photo library to import bottle photos for inventory."
+          "photosPermission": "BarTools accesses your photo library to import bottle photos for inventory."
         }
       ],
       "./plugins/with-privacy-manifest.cjs",

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -23,9 +23,12 @@
       "bundleIdentifier": "com.bartools.barback",
       "infoPlist": {
         "NSCameraUsageDescription": "BarBack uses the camera to photograph bottles for inventory identification.",
-        "NSPhotoLibraryUsageDescription": "BarBack accesses your photo library to import bottle photos for inventory."
+        "NSPhotoLibraryUsageDescription": "BarBack accesses your photo library to import bottle photos for inventory.",
+        "NSLocationWhenInUseUsageDescription": "BarBack does not use your location. This key is required because a bundled dependency references the Location API.",
+        "NSMicrophoneUsageDescription": "BarBack does not record audio. This key is required by the camera framework used to photograph bottles.",
+        "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "4"
+      "buildNumber": "6"
     },
     "android": {
       "package": "com.bartools.barback",
@@ -38,7 +41,7 @@
       "permissions": [
         "android.permission.CAMERA"
       ],
-      "versionCode": 4
+      "versionCode": 6
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -28,7 +28,7 @@
         "NSMicrophoneUsageDescription": "BarTools does not record audio. This key is required by the camera framework used to photograph bottles.",
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "10"
+      "buildNumber": "11"
     },
     "android": {
       "package": "com.bartools.barback",
@@ -47,17 +47,6 @@
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
-      [
-        "expo-build-properties",
-        {
-          "ios": {
-            "newArchEnabled": true
-          },
-          "android": {
-            "newArchEnabled": true
-          }
-        }
-      ],
       "expo-router",
       "expo-font",
       [

--- a/packages/mobile/app/(tabs)/inventory/add-manually.tsx
+++ b/packages/mobile/app/(tabs)/inventory/add-manually.tsx
@@ -56,7 +56,7 @@ export default function AddManuallyScreen() {
         <Pressable onPress={() => router.back()} hitSlop={12}>
           <MaterialCommunityIcons name="arrow-left" size={24} color={theme.primary} />
         </Pressable>
-        <Text style={[styles.headerTitle, { color: theme.primary }]}>BarBack</Text>
+        <Text style={[styles.headerTitle, { color: theme.primary }]}>BarTools</Text>
       </View>
 
       <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>

--- a/packages/mobile/app/(tabs)/inventory/confirm.tsx
+++ b/packages/mobile/app/(tabs)/inventory/confirm.tsx
@@ -41,7 +41,7 @@ export default function ConfirmScanScreen() {
           <Pressable onPress={() => router.back()} hitSlop={12}>
             <MaterialCommunityIcons name="arrow-left" size={24} color={theme.primary} />
           </Pressable>
-          <Text style={[styles.headerTitle, { color: theme.primary }]}>BarBack</Text>
+          <Text style={[styles.headerTitle, { color: theme.primary }]}>BarTools</Text>
         </View>
       </View>
 

--- a/packages/mobile/app/(tabs)/inventory/scan.tsx
+++ b/packages/mobile/app/(tabs)/inventory/scan.tsx
@@ -61,7 +61,7 @@ export default function InventoryScanScreen() {
           >
             <MaterialCommunityIcons name="arrow-left" size={24} color={theme.primary} />
           </Pressable>
-          <Text style={[styles.headerTitle, { color: theme.primary }]}>BarBack</Text>
+          <Text style={[styles.headerTitle, { color: theme.primary }]}>BarTools</Text>
         </View>
       </SafeAreaView>
 

--- a/packages/mobile/components/AgeGate.tsx
+++ b/packages/mobile/components/AgeGate.tsx
@@ -50,7 +50,7 @@ export function AgeGate({ onVerified }: Readonly<AgeGateProps>) {
             Age Verification
           </Text>
           <Text style={[styles.subtitle, { color: theme.textMuted }]}>
-            BarBack is an alcohol identification app. You must be at least 21
+            BarTools is an alcohol identification app. You must be at least 21
             years old to continue.
           </Text>
 

--- a/packages/mobile/components/camera-capture.tsx
+++ b/packages/mobile/components/camera-capture.tsx
@@ -38,7 +38,7 @@ export function CameraCapture({ onPhotoTaken }: CameraCaptureProps) {
       <View style={styles.centered}>
         <Text style={styles.title}>Camera Permission</Text>
         <Text style={styles.subtitle}>
-          Allow BarBack to access your camera to scan bottles.
+          Allow BarTools to access your camera to scan bottles.
         </Text>
         <TouchableOpacity
           style={styles.settingsButton}

--- a/packages/mobile/declarations.d.ts
+++ b/packages/mobile/declarations.d.ts
@@ -1,5 +1,11 @@
 // Type declarations for packages without bundled types
 
+declare module '*.png'
+declare module '*.jpg'
+declare module '*.jpeg'
+declare module '*.webp'
+declare module '*.svg'
+
 declare module 'react-native-sse' {
   export default class EventSource {
     constructor(url: string, options?: { headers?: Record<string, string> })

--- a/packages/mobile/eas.json
+++ b/packages/mobile/eas.json
@@ -55,7 +55,7 @@
       "autoIncrement": true,
       "channel": "production",
       "env": {
-        "EXPO_PUBLIC_BARTOOLS_API_URL": "https://bartools-backend-staging-zjausnxoyq-ue.a.run.app"
+        "EXPO_PUBLIC_BARTOOLS_API_URL": "https://bartools-backend-prod-ovhqgvlj5q-ue.a.run.app"
       }
     },
     "production-apk": {

--- a/packages/mobile/eas.json
+++ b/packages/mobile/eas.json
@@ -34,23 +34,36 @@
     },
     "staging": {
       "extends": "base",
-      "distribution": "internal",
-      "ios": {
-        "simulator": false
-      },
-      "android": {
-        "buildType": "apk"
-      },
+      "distribution": "store",
+      "autoIncrement": true,
       "channel": "staging",
       "env": {
+        "APP_VARIANT": "staging",
         "EXPO_PUBLIC_BARTOOLS_API_URL": "https://bartools-backend-staging-zjausnxoyq-ue.a.run.app"
+      }
+    },
+    "staging-apk": {
+      "extends": "staging",
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
       }
     },
     "production": {
       "extends": "base",
       "distribution": "store",
       "autoIncrement": true,
-      "channel": "production"
+      "channel": "production",
+      "env": {
+        "EXPO_PUBLIC_BARTOOLS_API_URL": "https://bartools-backend-staging-zjausnxoyq-ue.a.run.app"
+      }
+    },
+    "production-apk": {
+      "extends": "production",
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
     }
   },
   "submit": {
@@ -61,6 +74,14 @@
       },
       "ios": {
         "ascAppId": "6762476579",
+        "ascApiKeyPath": "./AuthKey.p8",
+        "ascApiKeyIssuerId": "38efbc62-e5f6-4f50-9adf-d04d8b188130",
+        "ascApiKeyId": "BXUN39KMTG"
+      }
+    },
+    "staging": {
+      "ios": {
+        "ascAppId": "6762489654",
         "ascApiKeyPath": "./AuthKey.p8",
         "ascApiKeyIssuerId": "38efbc62-e5f6-4f50-9adf-d04d8b188130",
         "ascApiKeyId": "BXUN39KMTG"

--- a/packages/mobile/lib/age-verification.ts
+++ b/packages/mobile/lib/age-verification.ts
@@ -1,4 +1,4 @@
-const STORAGE_KEY = 'barback:age_verified'
+const STORAGE_KEY = 'bartools:age_verified'
 const MINIMUM_AGE = 21
 
 export { STORAGE_KEY, MINIMUM_AGE }

--- a/packages/mobile/lib/storage.ts
+++ b/packages/mobile/lib/storage.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
-const AGE_VERIFIED_KEY = 'barback:age_verified'
+const AGE_VERIFIED_KEY = 'bartools:age_verified'
 
 export async function getAgeVerified(): Promise<boolean> {
   const value = await AsyncStorage.getItem(AGE_VERIFIED_KEY)

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -20,6 +20,7 @@
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.20",
     "expo-file-system": "~19.0.21",
+    "expo-font": "~14.0.11",
     "expo-image-picker": "~17.0.10",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
@@ -33,6 +34,7 @@
     "react-native-screens": "~4.16.0",
     "react-native-sse": "^1.2.1",
     "react-native-vision-camera": "^4.7.3",
+    "react-native-worklets": "^0.8.0",
     "react-native-worklets-core": "^1.6.3"
   },
   "devDependencies": {
@@ -46,5 +48,14 @@
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.58.0"
   },
-  "private": true
+  "private": true,
+  "expo": {
+    "install": {
+      "exclude": [
+        "@shopify/react-native-skia",
+        "react-native-reanimated",
+        "react-native-worklets"
+      ]
+    }
+  }
 }

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -7,7 +7,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "eas-build-post-install": "bunx install-skia"
   },
   "dependencies": {
     "@bartools/types": "workspace:*",

--- a/packages/mobile/plugins/native/BottleSegFrameProcessor.m
+++ b/packages/mobile/plugins/native/BottleSegFrameProcessor.m
@@ -3,6 +3,8 @@
 
 #if __has_include("BarBack-Swift.h")
 #import "BarBack-Swift.h"
+#elif __has_include("BarBackStaging-Swift.h")
+#import "BarBackStaging-Swift.h"
 #else
 @class BottleSegFrameProcessor;
 #endif

--- a/packages/mobile/plugins/native/BottleSegFrameProcessor.m
+++ b/packages/mobile/plugins/native/BottleSegFrameProcessor.m
@@ -1,10 +1,10 @@
 #import <VisionCamera/FrameProcessorPlugin.h>
 #import <VisionCamera/FrameProcessorPluginRegistry.h>
 
-#if __has_include("BarBack-Swift.h")
-#import "BarBack-Swift.h"
-#elif __has_include("BarBackStaging-Swift.h")
-#import "BarBackStaging-Swift.h"
+#if __has_include("BarTools-Swift.h")
+#import "BarTools-Swift.h"
+#elif __has_include("BarToolsStaging-Swift.h")
+#import "BarToolsStaging-Swift.h"
 #else
 @class BottleSegFrameProcessor;
 #endif

--- a/packages/mobile/plugins/with-bottle-seg-plugin.cjs
+++ b/packages/mobile/plugins/with-bottle-seg-plugin.cjs
@@ -93,7 +93,7 @@ function addFolderResource(proj, filePath, targetUuid, groupKey) {
   const buildFileUuid = proj.generateUuid();
 
   // PBXFileReference entry — folder reference (Xcode bundles whole dir).
-  // path includes the parent dir ("BarBack/foo.mlpackage") because the BarBack
+  // path includes the parent dir ("BarTools/foo.mlpackage") because the BarTools
   // group has no path attribute, so paths are relative to project root.
   const fileRefSection = proj.hash.project.objects.PBXFileReference;
   fileRefSection[fileRefUuid] = {
@@ -105,7 +105,7 @@ function addFolderResource(proj, filePath, targetUuid, groupKey) {
   };
   fileRefSection[`${fileRefUuid}_comment`] = basename;
 
-  // Add to the BarBack group's children
+  // Add to the BarTools group's children
   const groups = proj.hash.project.objects.PBXGroup;
   const group = groups[groupKey];
   group.children = group.children || [];


### PR DESCRIPTION
## Summary

- Adds a second iOS build variant (`com.bartools.barback.staging` → ASC app id `6762489654`) so staging TestFlight builds install alongside prod without cross-contamination.
- Introduces `app.config.ts` that reads `app.json` as a base and overlays bundle id, display name, and URL scheme when `APP_VARIANT=staging`. Production builds are unaffected (default branch returns the existing values).
- Restructures EAS profiles: `staging` flips to `distribution: store` / `autoIncrement` for TestFlight; new `staging-apk` and `production-apk` profiles emit sideloadable APKs via EAS install-by-link for Android (no Play Console dependency yet).
- Wires `EXPO_PUBLIC_BARTOOLS_API_URL` onto the `production` profile (pointed at staging Cloud Run for now — will flip to the prod service when real users arrive).
- Adds asset module declarations (`*.png/jpg/jpeg/webp/svg`) to `declarations.d.ts` so `tsc --noEmit` is clean without the gitignored `expo-env.d.ts`.

Reuses the single `AuthKey.p8` + issuer/key IDs across both ASC apps on the same Apple Developer team; no new secrets added to the repo.

## Test plan

- [x] `bunx tsc --noEmit` in `packages/mobile` passes.
- [x] `bun run lint` in `packages/mobile` passes.
- [x] `bun run test` from repo root passes (1 UI + 73 dashboard + 40 mobile).
- [x] `eas build --platform ios --profile staging` succeeds and the resulting build shows bundle id `com.bartools.barback.staging` in the EAS build detail.
- [ ] `eas submit --platform ios --profile staging --latest` uploads to the BarBack Staging ASC record.
- [ ] Staging TestFlight internal tester install verifies the app name renders as "BarBack (Staging)" and coexists with the prod BarBack install on the same phone.
- [ ] `eas build --platform android --profile staging-apk` produces an APK with bundle id `com.bartools.barback.staging` that installs via EAS link on an Android device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment-switched staging app variant (name, scheme, and platform IDs adjust per build)
  * Added APK/internal build profiles for staging and production and staging app-store submit config
  * Enabled importing common image asset types
  * Bumped mobile build/version, added iOS privacy entries and microphone/location permission text; added font plugin

* **Chores**
  * Added post-install helper script and new runtime deps; whitelisted a trusted native dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->