### PR TITLE
[codex] Rename BarBack branding to BarTools

### DIFF
--- a/packages/dashboard/coordination/golden-set-approved/README.md
+++ b/packages/dashboard/coordination/golden-set-approved/README.md
@@ -1,6 +1,6 @@
 # Golden Set Approved
 
-This folder contains the approved BARBACK web dashboard design references collected into one repo-local bundle.
+This folder contains the approved BARTOOLS web dashboard design references collected into one repo-local bundle.
 
 Use this folder when:
 - sharing the approved screen set with another team

--- a/packages/dashboard/coordination/golden-set-approved/report_detail_blocked_state/code.html
+++ b/packages/dashboard/coordination/golden-set-approved/report_detail_blocked_state/code.html
@@ -3,7 +3,7 @@
 <html class="dark" lang="en"><head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Access Unavailable - BARBACK</title>
+<title>Access Unavailable - BARTOOLS</title>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;family=Manrope:wght@200..800&amp;family=Space+Grotesk:wght@300..700&amp;display=swap" rel="stylesheet"/>
@@ -93,7 +93,7 @@
 </button>
 </div>
 <div class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5]">
-            BARBACK
+            BARTOOLS
         </div>
 <div class="w-10"></div>
 </header>

--- a/packages/dashboard/coordination/golden-set-approved/report_detail_comparison_emphasis_final/code.html
+++ b/packages/dashboard/coordination/golden-set-approved/report_detail_comparison_emphasis_final/code.html
@@ -99,7 +99,7 @@
 <button class="text-[#FFDCC5] dark:text-[#FFDCC5] hover:bg-[#353535] transition-colors duration-200 p-2 rounded-DEFAULT active:scale-95 transition-transform duration-150">
 <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 0;">arrow_back</span>
 </button>
-<span class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] font-bold">BARBACK</span>
+<span class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] font-bold">BARTOOLS</span>
 </div>
 <div class="hidden">
 <!-- Search bar hidden per JSON -->

--- a/packages/dashboard/coordination/golden-set-approved/report_detail_created/code.html
+++ b/packages/dashboard/coordination/golden-set-approved/report_detail_created/code.html
@@ -100,7 +100,7 @@
 <button class="text-[#FFDCC5] dark:text-[#FFDCC5] hover:bg-[#353535] transition-colors duration-200 p-2 rounded-DEFAULT active:scale-95 transition-transform duration-150 flex items-center justify-center">
 <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 0;">arrow_back</span>
 </button>
-<span class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] font-bold">BARBACK</span>
+<span class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] font-bold">BARTOOLS</span>
 </div>
 <div class="hidden">
 <!-- Search bar hidden per JSON -->

--- a/packages/dashboard/coordination/golden-set-approved/report_detail_failed_emphasis_final/code.html
+++ b/packages/dashboard/coordination/golden-set-approved/report_detail_failed_emphasis_final/code.html
@@ -116,7 +116,7 @@
 <button aria-label="Go back" class="hover:bg-[#353535] transition-colors duration-200 active:scale-95 transition-transform duration-150 p-2 rounded flex items-center justify-center text-[#FFDCC5] dark:text-[#FFDCC5]">
 <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 0;">arrow_back</span>
 </button>
-<h1 class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] font-bold">BARBACK</h1>
+<h1 class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] font-bold">BARTOOLS</h1>
 </div>
 <!-- Navigation area (Hidden on intent) -->
 <div class="hidden"></div>

--- a/packages/dashboard/coordination/golden-set-approved/report_detail_not_found_state/code.html
+++ b/packages/dashboard/coordination/golden-set-approved/report_detail_not_found_state/code.html
@@ -94,7 +94,7 @@
 </button>
 <!-- Brand Logo -->
 <div class="font-headline text-2xl tracking-[0.2em] uppercase text-primary">
-            BARBACK
+            BARTOOLS
         </div>
 <!-- Trailing Spacer (to balance the flex layout) -->
 <div class="w-10"></div>

--- a/packages/dashboard/coordination/golden-set-approved/report_detail_processing/code.html
+++ b/packages/dashboard/coordination/golden-set-approved/report_detail_processing/code.html
@@ -92,7 +92,7 @@
 <button aria-label="Go back" class="text-[#FFDCC5] dark:text-[#FFDCC5] hover:bg-[#353535] transition-colors duration-200 p-2 rounded-DEFAULT active:scale-95 transition-transform duration-150">
 <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">arrow_back</span>
 </button>
-<h1 class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] font-bold">BARBACK</h1>
+<h1 class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] font-bold">BARTOOLS</h1>
 </div>
 <div class="hidden">
 <!-- Search bar hidden per JSON -->

--- a/packages/dashboard/coordination/golden-set-approved/report_detail_reviewed_revised/code.html
+++ b/packages/dashboard/coordination/golden-set-approved/report_detail_reviewed_revised/code.html
@@ -94,7 +94,7 @@
 <button class="text-[#FFDCC5] dark:text-[#FFDCC5] hover:bg-[#353535] transition-colors duration-200 p-2 rounded-full flex items-center justify-center">
 <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 0;">arrow_back</span>
 </button>
-<h1 class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] font-bold">BARBACK</h1>
+<h1 class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] font-bold">BARTOOLS</h1>
 </div>
 <div class="hidden">
 <!-- Search bar hidden per JSON -->

--- a/packages/dashboard/coordination/golden-set-approved/report_detail_unreviewed_revised/code.html
+++ b/packages/dashboard/coordination/golden-set-approved/report_detail_unreviewed_revised/code.html
@@ -119,7 +119,7 @@
 <span class="material-symbols-outlined text-[#FFDCC5] dark:text-[#FFDCC5]">arrow_back</span>
 </div>
 <div class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] absolute left-1/2 -translate-x-1/2">
-            BARBACK
+            BARTOOLS
         </div>
 <div class="w-10"></div> <!-- Spacer for centering -->
 </header>

--- a/packages/dashboard/coordination/golden-set-approved/reports_list/code.html
+++ b/packages/dashboard/coordination/golden-set-approved/reports_list/code.html
@@ -3,7 +3,7 @@
 <html class="dark" lang="en"><head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Reports List - BARBACK</title>
+<title>Reports List - BARTOOLS</title>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:wght@400;700;800&amp;family=Manrope:wght@400;500;600&amp;family=Space+Grotesk:wght@400;500;700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
@@ -94,7 +94,7 @@
 <button aria-label="Go back" class="hover:bg-[#353535] transition-colors duration-200 p-2 rounded flex items-center justify-center active:scale-95 transition-transform duration-150">
 <span class="material-symbols-outlined">arrow_back</span>
 </button>
-<h1 class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] m-0 leading-none">BARBACK</h1>
+<h1 class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] m-0 leading-none">BARTOOLS</h1>
 </div>
 <div class="hidden">
 <!-- Search bar hidden per spec -->

--- a/packages/dashboard/coordination/golden-set-approved/reports_list_empty_state/code.html
+++ b/packages/dashboard/coordination/golden-set-approved/reports_list_empty_state/code.html
@@ -95,7 +95,7 @@
 <button aria-label="Go back" class="hover:bg-[#353535] transition-colors duration-200 p-2 rounded-sm active:scale-95 transition-transform duration-150">
 <span class="material-symbols-outlined" data-icon="arrow_back">arrow_back</span>
 </button>
-<h1 class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] font-bold">BARBACK</h1>
+<h1 class="font-['Newsreader'] text-2xl tracking-[0.2em] uppercase text-[#FFDCC5] dark:text-[#FFDCC5] font-bold">BARTOOLS</h1>
 </div>
 <div class="hidden md:block w-10"></div> <!-- Placeholder to balance flex-between -->
 </header>

--- a/packages/dashboard/coordination/golden-set-approved/reports_workbench_entry/code.html
+++ b/packages/dashboard/coordination/golden-set-approved/reports_workbench_entry/code.html
@@ -102,7 +102,7 @@
 <div class="max-w-2xl w-full flex flex-col items-center text-center space-y-12">
 <!-- Brand Wordmark -->
 <div class="flex flex-col items-center gap-2">
-<span class="font-headline text-2xl tracking-[0.2em] uppercase text-primary">BARBACK</span>
+<span class="font-headline text-2xl tracking-[0.2em] uppercase text-primary">BARTOOLS</span>
 <div class="w-8 h-[1px] bg-primary/30"></div>
 </div>
 <!-- Typographic Focus -->

--- a/packages/dashboard/coordination/reports-workbench-implementation/README.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/README.md
@@ -1,6 +1,6 @@
 # Reports Workbench Implementation
 
-This folder is the execution-facing plan for turning the approved golden-set mockups into the real BARBACK web frontend.
+This folder is the execution-facing plan for turning the approved golden-set mockups into the real BARTOOLS web frontend.
 
 This plan is intentionally narrower than the older dashboard-wide planning docs.
 
@@ -10,7 +10,7 @@ It assumes:
 - the approved web visual source is `packages/dashboard/coordination/golden-set-approved/`
 - the current web product is a reports-first workbench, not a full dashboard
 - React Aria is the interaction primitive layer
-- BARBACK-owned components and styles, not a third-party design system, define the visible product language
+- BARTOOLS-owned components and styles, not a third-party design system, define the visible product language
 
 ## Goal
 

--- a/packages/dashboard/coordination/reports-workbench-implementation/architecture-and-file-plan.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/architecture-and-file-plan.md
@@ -147,7 +147,7 @@ Should not own:
 
 ## Primitive Component Plan
 
-We should introduce small BARBACK-flavored primitives to prevent style drift:
+We should introduce small BARTOOLS-flavored primitives to prevent style drift:
 
 - `StatusChip`
   Shared status rendering for report and record states.
@@ -156,7 +156,7 @@ We should introduce small BARBACK-flavored primitives to prevent style drift:
   Small uppercase label used across comparison and metadata sections.
 
 - `AppWordmark`
-  Consistent BARBACK header identity.
+  Consistent BARTOOLS header identity.
 
 - `SurfaceCard`
   Shared surface wrapper for panels/cards if repetition appears.

--- a/packages/dashboard/coordination/reports-workbench-implementation/architecture-defaults.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/architecture-defaults.md
@@ -104,7 +104,7 @@ Do not prefer:
 ### 9. Prefer Product Primitives Over One-Off Styling
 
 If a visual pattern appears twice or more, prefer:
-- strengthening a local BARBACK primitive
+- strengthening a local BARTOOLS primitive
 
 Do not prefer:
 - copying CSS fragments into multiple screens

--- a/packages/dashboard/coordination/reports-workbench-implementation/architecture-renegotiation-protocol.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/architecture-renegotiation-protocol.md
@@ -38,7 +38,7 @@ These decisions are locked until consciously changed:
 3. The active web product is a reports-first workbench, not a general dashboard.
 4. Unsupported surfaces stay hidden or redirected rather than remaining as fake product pages.
 5. React Aria is the behavior and accessibility layer.
-6. BARBACK-owned styling and components define the visible product language.
+6. BARTOOLS-owned styling and components define the visible product language.
 7. Review remains report-level, not per-record submit.
 8. Fixtures and review routes are required for deterministic visual iteration.
 

--- a/packages/dashboard/coordination/reports-workbench-implementation/autonomy-envelope.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/autonomy-envelope.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document defines how much implementation autonomy is allowed for the BARBACK reports workbench.
+This document defines how much implementation autonomy is allowed for the BARTOOLS reports workbench.
 
 Its job is to make long-running execution possible without turning "autonomy" into silent drift.
 

--- a/packages/dashboard/coordination/reports-workbench-implementation/backpressure-and-review-gates.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/backpressure-and-review-gates.md
@@ -32,7 +32,7 @@ Symptoms:
 - interactive primitives quietly start dictating layout
 
 Counter-pressure:
-- BARBACK-owned shell and primitive components
+- BARTOOLS-owned shell and primitive components
 - review against golden-set screenshots
 - no direct use of stock table, shell, card, or badge aesthetics
 
@@ -138,7 +138,7 @@ Fail the gate if:
 ## Gate B: Shell Fidelity
 
 Before list/detail feature work:
-- `/` and `/reports` feel like the same BARBACK product family
+- `/` and `/reports` feel like the same BARTOOLS product family
 - shell is dark-first
 - top bar and content canvas feel deliberate
 - shell matches the token contract

--- a/packages/dashboard/coordination/reports-workbench-implementation/code-quality-gates.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/code-quality-gates.md
@@ -1,6 +1,6 @@
 # Code Quality Gates
 
-This document defines the code-quality backpressure for the BARBACK dashboard.
+This document defines the code-quality backpressure for the BARTOOLS dashboard.
 
 It exists to prevent a familiar failure mode:
 

--- a/packages/dashboard/coordination/reports-workbench-implementation/component-map.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/component-map.md
@@ -89,7 +89,7 @@ Responsibilities:
 - outer content framing
 
 Should render:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - restrained workbench entry CTA
 - child screen content
 
@@ -126,7 +126,7 @@ Important note:
 ### `WorkbenchTopBar`
 
 Responsibilities:
-- BARBACK identity
+- BARTOOLS identity
 - page-level back action if required by final composition
 - narrow workbench framing
 
@@ -151,7 +151,7 @@ Use for:
 - workbench shell
 
 Responsibilities:
-- consistent BARBACK identity treatment
+- consistent BARTOOLS identity treatment
 
 ### `StatusChip`
 

--- a/packages/dashboard/coordination/reports-workbench-implementation/dependency-decision-policy.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/dependency-decision-policy.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document defines the dependency policy for the BARBACK reports workbench.
+This document defines the dependency policy for the BARTOOLS reports workbench.
 
 Its job is to make dependency-related stop conditions explicit so the implementation run does not pretend that package changes are "small refactors."
 

--- a/packages/dashboard/coordination/reports-workbench-implementation/execution-plan.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/execution-plan.md
@@ -20,7 +20,7 @@ Done when:
 ## Phase 1: Design Token And Shell Refactor
 
 Goal:
-- make the app feel like BARBACK before refining individual screens
+- make the app feel like BARTOOLS before refining individual screens
 
 Tasks:
 - extract dashboard-local visual tokens from mobile-aligned direction
@@ -69,7 +69,7 @@ Goal:
 
 Tasks:
 - replace generic table presentation
-- implement BARBACK-owned list rows instead of library-shaped table defaults
+- implement BARTOOLS-owned list rows instead of library-shaped table defaults
 - implement final row/card composition
 - align status chip treatment
 - implement empty state in same family

--- a/packages/dashboard/coordination/reports-workbench-implementation/implementation-principles.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/implementation-principles.md
@@ -66,7 +66,7 @@ Today the reports pages exist, but they are still generic product scaffolding:
 The target is not "same data, prettier cards."
 
 The target is:
-- a report workbench that reads like the approved BARBACK desktop product
+- a report workbench that reads like the approved BARTOOLS desktop product
 - deterministic screen states matching the golden set
 - a code structure that allows future backend wiring without redesign
 
@@ -123,7 +123,7 @@ UI consequences:
 
 ## Design System Rules
 
-The web app should feel like BARBACK, not like a component library demo.
+The web app should feel like BARTOOLS, not like a component library demo.
 
 That means:
 - define dashboard-local tokens
@@ -148,7 +148,7 @@ The scaffolding is successful when a developer can open a route and compare it d
 
 Every major implementation pass should be checked against these questions:
 
-1. Does this screen still look like BARBACK, or did it regress into a library demo?
+1. Does this screen still look like BARTOOLS, or did it regress into a library demo?
 2. Does this interaction imply backend capabilities we do not have?
 3. Did any old full-dashboard scope leak back in?
 4. Are we preserving the calm operational tone?

--- a/packages/dashboard/coordination/reports-workbench-implementation/phase-1-2-file-checklist.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/phase-1-2-file-checklist.md
@@ -37,20 +37,20 @@ The point is to reduce planning drift once coding starts.
   Current file likely becomes a compatibility wrapper or gets broken apart.
 
 - `src/components/states/state-panel.tsx`
-  Keep only if it can survive BARBACK styling. Otherwise replace with more specific state components.
+  Keep only if it can survive BARTOOLS styling. Otherwise replace with more specific state components.
 
 ## Phase 1: Design Token And Shell Refactor
 
 ## Objective
 
-Make `/` and `/reports` feel like the same BARBACK product family before deeper feature work.
+Make `/` and `/reports` feel like the same BARTOOLS product family before deeper feature work.
 
 ## 1. Theme And Token Files
 
 ### `src/app/theme/tokens.ts`
 
 Phase 1 action:
-- define the locked BARBACK surface, text, accent, spacing, radius, border, and shadow tokens
+- define the locked BARTOOLS surface, text, accent, spacing, radius, border, and shadow tokens
 - implement the values from `visual-token-spec.md`
 
 ### `src/app/theme/typography.ts`
@@ -103,7 +103,7 @@ Phase 1 action:
 ### `src/components/shell/public/public-top-bar.tsx`
 
 Phase 1 action:
-- own the public BARBACK wordmark treatment
+- own the public BARTOOLS wordmark treatment
 - keep CTA framing restrained if the top bar needs an action at all
 
 ### `src/components/shell/workbench/workbench-shell.tsx`
@@ -199,7 +199,7 @@ Responsibilities:
 
 ## Phase 1 Completion Checklist
 
-- `/` looks like BARBACK entry surface, not generic auth shell
+- `/` looks like BARTOOLS entry surface, not generic auth shell
 - `/reports` looks like the same product family
 - shell no longer depends on sidebar-heavy layout assumptions
 - status styling is centralized

--- a/packages/dashboard/coordination/reports-workbench-implementation/review-evidence/2026-04-16-token-and-shell-audit/checklist.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/review-evidence/2026-04-16-token-and-shell-audit/checklist.md
@@ -1,6 +1,6 @@
 | Screen | Route | Golden Reference | Screenshot | Visual Verdict | Semantic Verdict | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| Entry | `/` | `golden-set-approved/reports_workbench_entry` | `screens/01-entry.png` | `pass` | `pass` | Typography, CTA emphasis, and calm dark shell now read much closer to the approved BARBACK entry family. |
+| Entry | `/` | `golden-set-approved/reports_workbench_entry` | `screens/01-entry.png` | `pass` | `pass` | Typography, CTA emphasis, and calm dark shell now read much closer to the approved BARTOOLS entry family. |
 | Reports List | `/reports` | `golden-set-approved/reports_list` | `screens/02-reports-list.png` | `pass-with-notes` | `pass` | Row chrome, wordmark shell, and chip palette are aligned; fixture data still differs from the literal mockup content and the list remains slightly more spacious. |
 | Reports Empty | `/__review/reports/empty` | `golden-set-approved/reports_list_empty_state` | `screens/03-reports-empty.png` | `pass` | `pass` | Empty state stays calm and centered without inventing troubleshooting or unsupported product scope. |
 | Report Created | `/__review/report/created` | `golden-set-approved/report_detail_created` | `screens/04-report-created.png` | `pass-with-notes` | `pass` | The state remains minimal and truthful, but the explainer slab is still thinner and less deliberate than the approved frame. |

--- a/packages/dashboard/coordination/reports-workbench-implementation/scaffolding-backlog.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/scaffolding-backlog.md
@@ -15,7 +15,7 @@ It is intentionally concrete and file-oriented.
 ## Pass 2: Theme And Primitive Scaffold
 
 - create dashboard-local token source for colors, spacing, radii, typography intent
-- add BARBACK-specific chip/label/logo primitives
+- add BARTOOLS-specific chip/label/logo primitives
 - define shared surface primitives if repetition becomes obvious
 - remove remaining starter-feeling shell styles
 - use the canonical file layout from `architecture-and-file-plan.md`

--- a/packages/dashboard/coordination/reports-workbench-implementation/screen-composition-spec.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/screen-composition-spec.md
@@ -1,6 +1,6 @@
 # Screen Composition Spec
 
-This document locks the screen-by-screen blueprint for the BARBACK web reports workbench.
+This document locks the screen-by-screen blueprint for the BARTOOLS web reports workbench.
 
 It exists because strong tokens and strong state rules are still not enough if block order, responsive collapse, and copy remain mushy.
 
@@ -30,7 +30,7 @@ This document defines:
 
 These decisions are now closed:
 
-1. Reports list uses custom BARBACK rows, not a stock data-table component.
+1. Reports list uses custom BARTOOLS rows, not a stock data-table component.
 2. Created state does not render a fake extracted-records section.
 3. Blocked state includes a disabled `Submit Review` button plus a `Back to Reports` action.
 4. Unreviewed uses a scrubber or rail-like tenths selector.
@@ -51,7 +51,7 @@ Use these planning breakpoints:
 
 Across list and detail screens:
 - use a top bar, not a sidebar
-- keep the BARBACK wordmark visible in the top bar
+- keep the BARTOOLS wordmark visible in the top bar
 - keep the main content inside a deliberate centered canvas
 - keep decorative chrome minimal
 - avoid floating utility widgets, search bars, and secondary nav
@@ -88,7 +88,7 @@ Reference:
 
 ### Locked Copy
 
-- wordmark: `BARBACK`
+- wordmark: `BARTOOLS`
 - headline: `Reports Workbench`
 - supporting copy: `Open recent reports and inspect records from desktop.`
 - CTA: `Open Reports`

--- a/packages/dashboard/coordination/reports-workbench-implementation/screen-inventory.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/screen-inventory.md
@@ -67,7 +67,7 @@ Purpose:
 
 Must include:
 - public shell
-- BARBACK identity
+- BARTOOLS identity
 - reports-workbench framing
 - restrained primary CTA toward reports workbench
 
@@ -95,7 +95,7 @@ Must include:
 - report status
 
 Implementation decision now locked:
-- reports list uses custom BARBACK row composition
+- reports list uses custom BARTOOLS row composition
 - stock data-table components are not allowed to define the visible list presentation
 - semantic list markup or CSS grid composition is fine
 - stock admin-table chrome is not

--- a/packages/dashboard/coordination/reports-workbench-implementation/ticket-backlog.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/ticket-backlog.md
@@ -225,7 +225,7 @@ Validation:
 
 Outcome:
 
-- make the workbench shell feel like the approved BARBACK product family
+- make the workbench shell feel like the approved BARTOOLS product family
 - tighten top bar, canvas width, gutters, and detail/list frame behavior
 
 Current baseline:

--- a/packages/dashboard/coordination/reports-workbench-implementation/visual-deviation-policy.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/visual-deviation-policy.md
@@ -117,4 +117,4 @@ During a long unattended run:
 
 ## Success Condition
 
-This policy is working if the implemented screens are recognizably the approved BARBACK product, but the run does not grind to a halt over trivial pixel drama.
+This policy is working if the implemented screens are recognizably the approved BARTOOLS product, but the run does not grind to a halt over trivial pixel drama.

--- a/packages/dashboard/coordination/reports-workbench-implementation/visual-token-spec.md
+++ b/packages/dashboard/coordination/reports-workbench-implementation/visual-token-spec.md
@@ -1,6 +1,6 @@
 # Visual Token Spec
 
-This document is the hard visual contract for the BARBACK web reports workbench.
+This document is the hard visual contract for the BARTOOLS web reports workbench.
 
 It exists to answer one question:
 

--- a/packages/dashboard/coordination/stitch_handoff_selection.md
+++ b/packages/dashboard/coordination/stitch_handoff_selection.md
@@ -1,6 +1,6 @@
 # Stitch Handoff Selection
 
-This document identifies the canonical mockups and locked design choices for the BARBACK web reports workbench handoff.
+This document identifies the canonical mockups and locked design choices for the BARTOOLS web reports workbench handoff.
 
 Use this when:
 - aligning with the mobile team on visual direction
@@ -40,7 +40,7 @@ The current recommendation is:
 
 Why this matters:
 
-- the approved screens are visually aligned with the dark-first BARBACK direction
+- the approved screens are visually aligned with the dark-first BARTOOLS direction
 - the worst fake-product copy has been removed
 - the per-record submit buttons are gone
 - the remaining action model is close enough to backend truth to implement carefully
@@ -100,7 +100,7 @@ These decisions should be visually reinforced in the final Stitch handoff.
 - Dark-first composition should dominate.
 - Mobile-derived typography and color language should dominate over generic web-dashboard instincts.
 - The surface should feel calm, precise, and operational.
-- The design should feel like a desktop extension of BARBACK, not a separate SaaS product.
+- The design should feel like a desktop extension of BARTOOLS, not a separate SaaS product.
 
 ### Layout And Shell
 
@@ -161,7 +161,7 @@ These issues are still present in the selected exports and should not be mistake
 
 In `golden-set-approved/report_detail_failed_emphasis_final`:
 
-- the page now matches the dark-first BARBACK family much better
+- the page now matches the dark-first BARTOOLS family much better
 - per-record submit buttons are gone, which is a major improvement
 - the bogus weight-entry and kilogram language is gone
 - the bottom action label is now a single report-level `Submit Review`, which is acceptable but should still be implemented carefully against the backend review contract
@@ -179,7 +179,7 @@ In `golden-set-approved/report_detail_comparison_emphasis_final`:
 After the final Stitch cleanup pass, a reviewer should be able to understand:
 
 - which screens are canonical
-- what the desktop BARBACK shell feels like
+- what the desktop BARTOOLS shell feels like
 - how reports move from processing to review
 - how unreviewed, reviewed, failed, and comparison-heavy states differ
 - how bottle selection and fill-level correction should look

--- a/packages/dashboard/coordination/stitch_prompt_v2.md
+++ b/packages/dashboard/coordination/stitch_prompt_v2.md
@@ -1,9 +1,9 @@
-# Stitch Prompt: BARBACK Web Dashboard
+# Stitch Prompt: BARTOOLS Web Dashboard
 
 Use the following prompt in Stitch.
 
 ```text
-Design only a narrow desktop report-review workbench for BARBACK.
+Design only a narrow desktop report-review workbench for BARTOOLS.
 
 Do not design a general dashboard.
 Do not design an admin console.
@@ -30,7 +30,7 @@ Do not treat it as a source of truth for:
 
 If the linked project contains any page, module, navigation, metric, action, or concept not explicitly allowed in this prompt, ignore it.
 
-The mobile BARBACK app is the source of truth for design.
+The mobile BARTOOLS app is the source of truth for design.
 The backend reports workflow is the source of truth for functionality.
 
 If mobile design language conflicts with generic desktop dashboard conventions:
@@ -50,7 +50,7 @@ Do not design for speculative future backend capabilities.
 1. CORE PRODUCT TRUTH
 ========================================
 
-This web surface is a desktop companion to BARBACK mobile.
+This web surface is a desktop companion to BARTOOLS mobile.
 
 It is for one job:
 - reviewing reports
@@ -344,7 +344,7 @@ Only the content within the shared template may change by state.
 Use one restrained global shell.
 
 Allowed shell elements:
-- BARBACK wordmark / brand marker
+- BARTOOLS wordmark / brand marker
 - minimal top bar
 - current page title context
 - optional single back link where relevant
@@ -376,7 +376,7 @@ It is not an account entry flow.
 It should be a restrained launch surface for the reports workbench.
 
 It may contain:
-- BARBACK identity
+- BARTOOLS identity
 - a concise heading
 - one short descriptive paragraph
 - one primary action leading into reports
@@ -663,7 +663,7 @@ It should not:
 15. VISUAL SYSTEM REQUIREMENTS
 ========================================
 
-Match BARBACK mobile in spirit and in concrete typographic/material choices.
+Match BARTOOLS mobile in spirit and in concrete typographic/material choices.
 
 Typography:
 - display / major headings: Newsreader
@@ -784,7 +784,7 @@ The result should be implementation-directed, not ideation-directed.
 
 The design succeeds only if all of the following are true:
 
-1. It is unmistakably BARBACK.
+1. It is unmistakably BARTOOLS.
 2. It visually defers to the linked mobile design language.
 3. It functionally stays inside the backend reports workflow and nowhere else.
 4. Every visible element maps to a backend field, route, or state described in this prompt.

--- a/packages/dashboard/coordination/stitch_prompt_v3.md
+++ b/packages/dashboard/coordination/stitch_prompt_v3.md
@@ -1,9 +1,9 @@
-# Stitch Prompt V3: BARBACK Web Reports Workbench
+# Stitch Prompt V3: BARTOOLS Web Reports Workbench
 
 Use the following prompt in a fresh Stitch project.
 
 ```text
-Design a desktop web reports workbench for BARBACK.
+Design a desktop web reports workbench for BARTOOLS.
 
 This is a fresh project.
 Do not inherit assumptions from prior Stitch attempts.
@@ -15,7 +15,7 @@ Do not reuse prior Stitch action vocabulary.
 Do not reuse prior Stitch “luxury dashboard” instincts.
 
 The design must defer to:
-- the BARBACK mobile app for design
+- the BARTOOLS mobile app for design
 - the backend reports workflow for functionality
 
 Primary visual reference:
@@ -75,7 +75,7 @@ This is:
 - a report review desk
 - a quiet operational workbench
 - a desktop reading and inspection surface
-- a BARBACK companion interface
+- a BARTOOLS companion interface
 
 The product job is extremely narrow:
 - open reports
@@ -87,7 +87,7 @@ The product job is extremely narrow:
 
 The web surface must not imply broader authority than the backend actually exposes.
 The web surface must not create any new product obligations for mobile or backend.
-The web surface must feel subordinate to the existing BARBACK product family, not like a new platform.
+The web surface must feel subordinate to the existing BARTOOLS product family, not like a new platform.
 
 
 ==================================================
@@ -97,7 +97,7 @@ The web surface must feel subordinate to the existing BARBACK product family, no
 There are exactly two sources of truth.
 
 Design source of truth:
-- BARBACK mobile app
+- BARTOOLS mobile app
 - the linked Stitch project only as visual reference
 
 Functional source of truth:
@@ -525,7 +525,7 @@ Do not create a design brief that:
 9. EXACT VISUAL SOURCE OF TRUTH
 ==================================================
 
-The web surface must feel like BARBACK mobile translated to desktop.
+The web surface must feel like BARTOOLS mobile translated to desktop.
 
 Typography:
 - major headings: Newsreader
@@ -595,7 +595,7 @@ The mood should not come from:
 There is one shell.
 
 Allowed shell elements:
-- BARBACK wordmark or simple brand mark
+- BARTOOLS wordmark or simple brand mark
 - one restrained top bar
 - one optional back link when appropriate
 
@@ -630,7 +630,7 @@ This is not product marketing.
 It is a sparse launch surface for the reports workbench.
 
 Allowed content:
-- BARBACK identity
+- BARTOOLS identity
 - one heading
 - one short paragraph
 - one primary action leading into reports
@@ -1012,7 +1012,7 @@ Do not write copy that sounds like an enterprise dashboard.
 Provide exactly:
 - 11 screens
 - one coherent visual system across them
-- one clear desktop adaptation of BARBACK mobile
+- one clear desktop adaptation of BARTOOLS mobile
 
 Do not provide:
 - system manifesto
@@ -1672,7 +1672,7 @@ Before finalizing the design, validate all of the following:
 
 1. Does every visible thing map directly to the backend truth described above?
 2. Are all statuses named exactly as the backend names them?
-3. Is BARBACK mobile clearly the visual parent?
+3. Is BARTOOLS mobile clearly the visual parent?
 4. Is Manrope used for body copy rather than Inter?
 5. Are there zero sidebars, zero footer utility links, and zero profile/notification controls?
 6. Are there zero synthetic metrics?

--- a/packages/dashboard/coordination/stitch_prompt_v4.md
+++ b/packages/dashboard/coordination/stitch_prompt_v4.md
@@ -1,9 +1,9 @@
-# Stitch Prompt V4: BARBACK Web Reports Workbench
+# Stitch Prompt V4: BARTOOLS Web Reports Workbench
 
 Use the following prompt in a fresh Stitch project.
 
 ```text
-Design a desktop web reports workbench for BARBACK.
+Design a desktop web reports workbench for BARTOOLS.
 
 This is a fresh project.
 Do not inherit assumptions from prior Stitch attempts.
@@ -15,7 +15,7 @@ Do not reuse prior Stitch action vocabulary.
 Do not reuse prior Stitch “luxury dashboard” instincts.
 
 The design must defer to:
-- the BARBACK mobile app for design
+- the BARTOOLS mobile app for design
 - the backend reports workflow for functionality
 
 Primary visual reference:
@@ -75,7 +75,7 @@ This is:
 - a report review desk
 - a quiet operational workbench
 - a desktop reading and inspection surface
-- a BARBACK companion interface
+- a BARTOOLS companion interface
 
 The product job is extremely narrow:
 - open reports
@@ -87,7 +87,7 @@ The product job is extremely narrow:
 
 The web surface must not imply broader authority than the backend actually exposes.
 The web surface must not create any new product obligations for mobile or backend.
-The web surface must feel subordinate to the existing BARBACK product family, not like a new platform.
+The web surface must feel subordinate to the existing BARTOOLS product family, not like a new platform.
 
 
 ==================================================
@@ -97,7 +97,7 @@ The web surface must feel subordinate to the existing BARBACK product family, no
 There are exactly two sources of truth.
 
 Design source of truth:
-- BARBACK mobile app
+- BARTOOLS mobile app
 - the linked Stitch project only as visual reference
 
 Functional source of truth:
@@ -525,7 +525,7 @@ Do not create a design brief that:
 9. EXACT VISUAL SOURCE OF TRUTH
 ==================================================
 
-The web surface must feel like BARBACK mobile translated to desktop.
+The web surface must feel like BARTOOLS mobile translated to desktop.
 
 Typography:
 - major headings: Newsreader
@@ -595,7 +595,7 @@ The mood should not come from:
 There is one shell.
 
 Allowed shell elements:
-- BARBACK wordmark or simple brand mark
+- BARTOOLS wordmark or simple brand mark
 - one restrained top bar
 - one optional back link when appropriate
 
@@ -630,7 +630,7 @@ This is not product marketing.
 It is a sparse launch surface for the reports workbench.
 
 Allowed content:
-- BARBACK identity
+- BARTOOLS identity
 - one heading
 - one short paragraph
 - one primary action leading into reports
@@ -1012,7 +1012,7 @@ Do not write copy that sounds like an enterprise dashboard.
 Provide exactly:
 - 11 screens
 - one coherent visual system across them
-- one clear desktop adaptation of BARBACK mobile
+- one clear desktop adaptation of BARTOOLS mobile
 
 Do not provide:
 - system manifesto
@@ -1902,7 +1902,7 @@ It exists to open reports.
 It exists to calmly state the integration limitation.
 
 Allowed entry surface elements:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - heading
 - one short explanatory sentence
 - one primary action to open reports
@@ -1932,7 +1932,7 @@ Disallowed heading ideas:
 - Operations Hub
 - Inventory Command
 - Review Console
-- BARBACK Reserve
+- BARTOOLS Reserve
 - Ledger Workbench
 
 Allowed body copy tone:
@@ -2836,7 +2836,7 @@ Disallowed industrial nouns:
 If you are about to write any of the following, stop.
 
 Forbidden on entry screen:
-- BARBACK Reserve
+- BARTOOLS Reserve
 - Review Control Center
 - Daily Operations Hub
 
@@ -2962,7 +2962,7 @@ This section exists because Stitch keeps hallucinating titles and metadata clust
 Use this as a screen-by-screen whitelist.
 
 Entry surface header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Reports Workbench heading
 
 Entry surface header may not include:
@@ -2973,7 +2973,7 @@ Entry surface header may not include:
 - workspace title
 
 Reports list header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - simple back path only if it makes sense
 - Reports heading
 - one short supporting sentence
@@ -2986,7 +2986,7 @@ Reports list header may not include:
 - utility links
 
 Created screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - created status chip
@@ -3001,7 +3001,7 @@ Created screen header may not include:
 - diagnostics
 
 Processing screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - processing status chip
@@ -3016,7 +3016,7 @@ Processing screen header may not include:
 - AI icon cluster
 
 Unreviewed screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - unreviewed status chip
@@ -3032,7 +3032,7 @@ Unreviewed screen header may not include:
 - Review All
 
 Reviewed screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - reviewed status chip
@@ -3048,7 +3048,7 @@ Reviewed screen header may not include:
 - profile icon
 
 Failed-emphasis screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - unreviewed status chip
@@ -3061,7 +3061,7 @@ Failed-emphasis screen header may not include:
 - retry action
 
 Comparison-emphasis screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - reviewed status chip
@@ -3073,7 +3073,7 @@ Comparison-emphasis screen header may not include:
 - document workflow copy
 
 Blocked screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports if shown
 - Access Unavailable
 
@@ -3083,7 +3083,7 @@ Blocked screen header may not include:
 - auth failure title
 
 Not-found screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports if shown
 - Report Not Found
 
@@ -3382,7 +3382,7 @@ Before finalizing the design, validate all of the following:
 
 1. Does every visible thing map directly to the backend truth described above?
 2. Are all statuses named exactly as the backend names them?
-3. Is BARBACK mobile clearly the visual parent?
+3. Is BARTOOLS mobile clearly the visual parent?
 4. Is Manrope used for body copy rather than Inter?
 5. Are there zero sidebars, zero footer utility links, and zero profile/notification controls?
 6. Are there zero synthetic metrics?

--- a/packages/dashboard/coordination/stitch_prompt_v4_1.md
+++ b/packages/dashboard/coordination/stitch_prompt_v4_1.md
@@ -1,9 +1,9 @@
-# Stitch Prompt V4: BARBACK Web Reports Workbench
+# Stitch Prompt V4: BARTOOLS Web Reports Workbench
 
 Use the following prompt in a fresh Stitch project.
 
 ```text
-Design a desktop web reports workbench for BARBACK.
+Design a desktop web reports workbench for BARTOOLS.
 
 This is a fresh project.
 Do not inherit assumptions from prior Stitch attempts.
@@ -15,7 +15,7 @@ Do not reuse prior Stitch action vocabulary.
 Do not reuse prior Stitch “luxury dashboard” instincts.
 
 The design must defer to:
-- the BARBACK mobile app for design
+- the BARTOOLS mobile app for design
 - the backend reports workflow for functionality
 
 Primary visual reference:
@@ -75,7 +75,7 @@ This is:
 - a report review desk
 - a quiet operational workbench
 - a desktop reading and inspection surface
-- a BARBACK companion interface
+- a BARTOOLS companion interface
 
 The product job is extremely narrow:
 - open reports
@@ -87,7 +87,7 @@ The product job is extremely narrow:
 
 The web surface must not imply broader authority than the backend actually exposes.
 The web surface must not create any new product obligations for mobile or backend.
-The web surface must feel subordinate to the existing BARBACK product family, not like a new platform.
+The web surface must feel subordinate to the existing BARTOOLS product family, not like a new platform.
 
 
 ==================================================
@@ -97,7 +97,7 @@ The web surface must feel subordinate to the existing BARBACK product family, no
 There are exactly two sources of truth.
 
 Design source of truth:
-- BARBACK mobile app
+- BARTOOLS mobile app
 - the linked Stitch project only as visual reference
 
 Functional source of truth:
@@ -532,7 +532,7 @@ Do not create a design brief that:
 9. EXACT VISUAL SOURCE OF TRUTH
 ==================================================
 
-The web surface must feel like BARBACK mobile translated to desktop.
+The web surface must feel like BARTOOLS mobile translated to desktop.
 
 Typography:
 - major headings: Newsreader
@@ -602,7 +602,7 @@ The mood should not come from:
 There is one shell.
 
 Allowed shell elements:
-- BARBACK wordmark or simple brand mark
+- BARTOOLS wordmark or simple brand mark
 - one restrained top bar
 - one optional back link when appropriate
 
@@ -637,7 +637,7 @@ This is not product marketing.
 It is a sparse launch surface for the reports workbench.
 
 Allowed content:
-- BARBACK identity
+- BARTOOLS identity
 - one heading
 - one short paragraph
 - one primary action leading into reports
@@ -1018,7 +1018,7 @@ Do not write copy that sounds like an enterprise dashboard.
 Provide exactly:
 - 11 screens
 - one coherent visual system across them
-- one clear desktop adaptation of BARBACK mobile
+- one clear desktop adaptation of BARTOOLS mobile
 
 Do not provide:
 - system manifesto
@@ -1908,7 +1908,7 @@ It exists to open reports.
 It exists to calmly state the integration limitation.
 
 Allowed entry surface elements:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - heading
 - one short explanatory sentence
 - one primary action to open reports
@@ -1938,7 +1938,7 @@ Disallowed heading ideas:
 - Operations Hub
 - Inventory Command
 - Review Console
-- BARBACK Reserve
+- BARTOOLS Reserve
 - Ledger Workbench
 
 Allowed body copy tone:
@@ -2842,7 +2842,7 @@ Disallowed industrial nouns:
 If you are about to write any of the following, stop.
 
 Forbidden on entry screen:
-- BARBACK Reserve
+- BARTOOLS Reserve
 - Review Control Center
 - Daily Operations Hub
 
@@ -2968,7 +2968,7 @@ This section exists because Stitch keeps hallucinating titles and metadata clust
 Use this as a screen-by-screen whitelist.
 
 Entry surface header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Reports Workbench heading
 
 Entry surface header may not include:
@@ -2979,7 +2979,7 @@ Entry surface header may not include:
 - workspace title
 
 Reports list header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - simple back path only if it makes sense
 - Reports heading
 - one short supporting sentence
@@ -2992,7 +2992,7 @@ Reports list header may not include:
 - utility links
 
 Created screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - created status chip
@@ -3007,7 +3007,7 @@ Created screen header may not include:
 - diagnostics
 
 Processing screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - processing status chip
@@ -3022,7 +3022,7 @@ Processing screen header may not include:
 - AI icon cluster
 
 Unreviewed screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - unreviewed status chip
@@ -3038,7 +3038,7 @@ Unreviewed screen header may not include:
 - Review All
 
 Reviewed screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - reviewed status chip
@@ -3054,7 +3054,7 @@ Reviewed screen header may not include:
 - profile icon
 
 Failed-emphasis screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - unreviewed status chip
@@ -3067,7 +3067,7 @@ Failed-emphasis screen header may not include:
 - retry action
 
 Comparison-emphasis screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - reviewed status chip
@@ -3079,7 +3079,7 @@ Comparison-emphasis screen header may not include:
 - document workflow copy
 
 Blocked screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports if shown
 - Access Unavailable
 
@@ -3089,7 +3089,7 @@ Blocked screen header may not include:
 - auth failure title
 
 Not-found screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports if shown
 - Report Not Found
 
@@ -3528,7 +3528,7 @@ Important interpretation rule:
 If you need example strings, copy the spirit of these.
 
 Entry screen:
-- BARBACK
+- BARTOOLS
 - Reports Workbench
 - Open recent reports and inspect records from desktop.
 - Open Reports
@@ -3627,7 +3627,7 @@ Before finalizing the design, validate all of the following:
 
 1. Does every visible thing map directly to the backend truth described above?
 2. Are all statuses named exactly as the backend names them?
-3. Is BARBACK mobile clearly the visual parent?
+3. Is BARTOOLS mobile clearly the visual parent?
 4. Is Manrope used for body copy rather than Inter?
 5. Are there zero sidebars, zero footer utility links, and zero profile/notification controls?
 6. Are there zero synthetic metrics?

--- a/packages/dashboard/coordination/stitch_prompt_v4_2.md
+++ b/packages/dashboard/coordination/stitch_prompt_v4_2.md
@@ -1,9 +1,9 @@
-# Stitch Prompt V4: BARBACK Web Reports Workbench
+# Stitch Prompt V4: BARTOOLS Web Reports Workbench
 
 Use the following prompt in a fresh Stitch project.
 
 ```text
-Design a desktop web reports workbench for BARBACK.
+Design a desktop web reports workbench for BARTOOLS.
 
 This is a fresh project.
 Do not inherit assumptions from prior Stitch attempts.
@@ -15,7 +15,7 @@ Do not reuse prior Stitch action vocabulary.
 Do not reuse prior Stitch “luxury dashboard” instincts.
 
 The design must defer to:
-- the BARBACK mobile app for design
+- the BARTOOLS mobile app for design
 - the backend reports workflow for functionality
 
 Primary visual reference:
@@ -75,7 +75,7 @@ This is:
 - a report review desk
 - a quiet operational workbench
 - a desktop reading and inspection surface
-- a BARBACK companion interface
+- a BARTOOLS companion interface
 
 The product job is extremely narrow:
 - open reports
@@ -87,7 +87,7 @@ The product job is extremely narrow:
 
 The web surface must not imply broader authority than the backend actually exposes.
 The web surface must not create any new product obligations for mobile or backend.
-The web surface must feel subordinate to the existing BARBACK product family, not like a new platform.
+The web surface must feel subordinate to the existing BARTOOLS product family, not like a new platform.
 
 
 ==================================================
@@ -97,7 +97,7 @@ The web surface must feel subordinate to the existing BARBACK product family, no
 There are exactly two sources of truth.
 
 Design source of truth:
-- BARBACK mobile app
+- BARTOOLS mobile app
 - the linked Stitch project only as visual reference
 
 Functional source of truth:
@@ -532,7 +532,7 @@ Do not create a design brief that:
 9. EXACT VISUAL SOURCE OF TRUTH
 ==================================================
 
-The web surface must feel like BARBACK mobile translated to desktop.
+The web surface must feel like BARTOOLS mobile translated to desktop.
 
 Typography:
 - major headings: Newsreader
@@ -602,7 +602,7 @@ The mood should not come from:
 There is one shell.
 
 Allowed shell elements:
-- BARBACK wordmark or simple brand mark
+- BARTOOLS wordmark or simple brand mark
 - one restrained top bar
 - one optional back link when appropriate
 
@@ -637,7 +637,7 @@ This is not product marketing.
 It is a sparse launch surface for the reports workbench.
 
 Allowed content:
-- BARBACK identity
+- BARTOOLS identity
 - one heading
 - one short paragraph
 - one primary action leading into reports
@@ -1018,7 +1018,7 @@ Do not write copy that sounds like an enterprise dashboard.
 Provide exactly:
 - 11 screens
 - one coherent visual system across them
-- one clear desktop adaptation of BARBACK mobile
+- one clear desktop adaptation of BARTOOLS mobile
 
 Do not provide:
 - system manifesto
@@ -1911,7 +1911,7 @@ It exists to open reports.
 It exists to calmly state the integration limitation.
 
 Allowed entry surface elements:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - heading
 - one short explanatory sentence
 - one primary action to open reports
@@ -1941,7 +1941,7 @@ Disallowed heading ideas:
 - Operations Hub
 - Inventory Command
 - Review Console
-- BARBACK Reserve
+- BARTOOLS Reserve
 - Ledger Workbench
 
 Allowed body copy tone:
@@ -2844,7 +2844,7 @@ Disallowed industrial nouns:
 If you are about to write any of the following, stop.
 
 Forbidden on entry screen:
-- BARBACK Reserve
+- BARTOOLS Reserve
 - Review Control Center
 - Daily Operations Hub
 
@@ -2970,7 +2970,7 @@ This section exists because Stitch keeps hallucinating titles and metadata clust
 Use this as a screen-by-screen whitelist.
 
 Entry surface header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Reports Workbench heading
 
 Entry surface header may not include:
@@ -2981,7 +2981,7 @@ Entry surface header may not include:
 - workspace title
 
 Reports list header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - simple back path only if it makes sense
 - Reports heading
 - one short supporting sentence
@@ -2994,7 +2994,7 @@ Reports list header may not include:
 - utility links
 
 Created screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - created status chip
@@ -3009,7 +3009,7 @@ Created screen header may not include:
 - diagnostics
 
 Processing screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - processing status chip
@@ -3024,7 +3024,7 @@ Processing screen header may not include:
 - AI icon cluster
 
 Unreviewed screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - unreviewed status chip
@@ -3040,7 +3040,7 @@ Unreviewed screen header may not include:
 - Review All
 
 Reviewed screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - reviewed status chip
@@ -3056,7 +3056,7 @@ Reviewed screen header may not include:
 - profile icon
 
 Failed-emphasis screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - unreviewed status chip
@@ -3069,7 +3069,7 @@ Failed-emphasis screen header may not include:
 - retry action
 
 Comparison-emphasis screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports
 - report id
 - reviewed status chip
@@ -3081,7 +3081,7 @@ Comparison-emphasis screen header may not include:
 - document workflow copy
 
 Blocked screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports if shown
 - Access Unavailable
 
@@ -3091,7 +3091,7 @@ Blocked screen header may not include:
 - auth failure title
 
 Not-found screen header may include:
-- BARBACK wordmark
+- BARTOOLS wordmark
 - Back to Reports if shown
 - Report Not Found
 
@@ -3595,7 +3595,7 @@ Important interpretation rule:
 If you need example strings, copy the spirit of these.
 
 Entry screen:
-- BARBACK
+- BARTOOLS
 - Reports Workbench
 - Open recent reports and inspect records from desktop.
 - Open Reports
@@ -3694,7 +3694,7 @@ Before finalizing the design, validate all of the following:
 
 1. Does every visible thing map directly to the backend truth described above?
 2. Are all statuses named exactly as the backend names them?
-3. Is BARBACK mobile clearly the visual parent?
+3. Is BARTOOLS mobile clearly the visual parent?
 4. Is Manrope used for body copy rather than Inter?
 5. Are there zero sidebars, zero footer utility links, and zero profile/notification controls?
 6. Are there zero synthetic metrics?

--- a/packages/dashboard/coordination/stitch_prompt_v4_3_handoff.md
+++ b/packages/dashboard/coordination/stitch_prompt_v4_3_handoff.md
@@ -1,11 +1,11 @@
 # Stitch Prompt V4.3: Final Handoff Pass
 
-Use this in the existing BARBACK v4 Stitch project by answering:
+Use this in the existing BARTOOLS v4 Stitch project by answering:
 
 `What do you want to change or create?`
 
 ```text
-Revise the current BARBACK web project in place.
+Revise the current BARTOOLS web project in place.
 
 This is not a new exploration pass.
 This is not a redesign pass.
@@ -26,10 +26,10 @@ That means:
 1. HANDOFF GOAL
 ==================================================
 
-Turn the current project into a final design-direction handoff for the BARBACK web reports workbench.
+Turn the current project into a final design-direction handoff for the BARTOOLS web reports workbench.
 
 The project should communicate:
-- this is a desktop companion to the mobile BARBACK product
+- this is a desktop companion to the mobile BARTOOLS product
 - this is a reports-first review surface
 - the backend reports workflow is the functional truth
 - the chosen desktop patterns are now settled enough to implement
@@ -85,7 +85,7 @@ Do not add:
 3. DESIGN SOURCE OF TRUTH
 ==================================================
 
-Defer to the BARBACK mobile app visual language.
+Defer to the BARTOOLS mobile app visual language.
 
 This web workbench should feel like a desktop adaptation of the mobile product:
 - dark-first
@@ -141,7 +141,7 @@ Normalize the project so the canonical choices are visually obvious:
 
 1. Make the shell consistent across all report-detail states.
 2. Make the reports list and empty states clearly part of the same family.
-3. Keep the dark-first BARBACK mood consistent throughout.
+3. Keep the dark-first BARTOOLS mood consistent throughout.
 4. Reduce any remaining ornamental UI that exists only to “make a dashboard.”
 5. Remove any copy or action that looks like dev-process leakage or product-scope hallucination.
 
@@ -198,7 +198,7 @@ These decisions are settled and should be reinforced, not debated:
 The following problem areas must be corrected in the current project.
 
 FAILED EMPHASIS SCREEN:
-- Make the overall page dark-first so it sits inside the same BARBACK visual family as the other winning screens.
+- Make the overall page dark-first so it sits inside the same BARTOOLS visual family as the other winning screens.
 - Remove per-record submit buttons.
 - Keep only the report-level review submission pattern.
 - Keep the page operational and recoverable, not alarming.
@@ -259,7 +259,7 @@ Keep copy literal, calm, and product-truthful.
 
 Before you finish, validate the following:
 
-1. Does every screen still belong to one coherent BARBACK family?
+1. Does every screen still belong to one coherent BARTOOLS family?
 2. Is the reports-first scope visually unmistakable?
 3. Are unsupported surfaces absent rather than merely de-emphasized?
 4. Are the report-detail states semantically different without turning into different products?

--- a/packages/dashboard/specs/landing-and-auth.md
+++ b/packages/dashboard/specs/landing-and-auth.md
@@ -33,7 +33,7 @@ For MVP, the public surface is purely marketing. Utility begins only after sign 
 ### Required Sections
 
 - Hero with concise value proposition
-- Short explanation of how BarBack works
+- Short explanation of how BarTools works
 - Primary CTAs for `Sign up` and `Sign in`
 - Lightweight proof section
   Suggested content: screenshot, product flow, or a short list of operational outcomes

--- a/packages/dashboard/src/components/primitives/app-wordmark.tsx
+++ b/packages/dashboard/src/components/primitives/app-wordmark.tsx
@@ -4,9 +4,9 @@ type AppWordmarkProps = {
 
 export function AppWordmark({ centered = false }: AppWordmarkProps) {
   return (
-    <div className={`bb-wordmark${centered ? ' bb-wordmark--centered' : ''}`}>
-      <span className="bb-wordmark__label">BARBACK</span>
-      <span className="bb-wordmark__rule" aria-hidden="true" />
+    <div className={`bt-wordmark${centered ? ' bt-wordmark--centered' : ''}`}>
+      <span className="bt-wordmark__label">BARTOOLS</span>
+      <span className="bt-wordmark__rule" aria-hidden="true" />
     </div>
   )
 }

--- a/packages/dashboard/src/components/primitives/button.tsx
+++ b/packages/dashboard/src/components/primitives/button.tsx
@@ -21,9 +21,9 @@ export function Button({
   ...props
 }: AppButtonProps) {
   const classes = [
-    'bb-button',
-    `bb-button--${variant}`,
-    fullWidth ? 'bb-button--full' : '',
+    'bt-button',
+    `bt-button--${variant}`,
+    fullWidth ? 'bt-button--full' : '',
     className,
   ]
     .filter(Boolean)

--- a/packages/dashboard/src/components/primitives/section-eyebrow.tsx
+++ b/packages/dashboard/src/components/primitives/section-eyebrow.tsx
@@ -5,5 +5,5 @@ type SectionEyebrowProps = {
 }
 
 export function SectionEyebrow({ children }: SectionEyebrowProps) {
-  return <p className="bb-section-eyebrow">{children}</p>
+  return <p className="bt-section-eyebrow">{children}</p>
 }

--- a/packages/dashboard/src/components/primitives/select.tsx
+++ b/packages/dashboard/src/components/primitives/select.tsx
@@ -9,9 +9,9 @@ export function Select({ className = '', hideLabel = false, id, label, ...props 
   const fieldId = id ?? label.toLowerCase().replaceAll(/\s+/g, '-')
 
   return (
-    <label className="bb-field">
-      <span className={`bb-field__label${hideLabel ? ' sr-only' : ''}`}>{label}</span>
-      <select className={`bb-select${className ? ` ${className}` : ''}`} id={fieldId} {...props} />
+    <label className="bt-field">
+      <span className={`bt-field__label${hideLabel ? ' sr-only' : ''}`}>{label}</span>
+      <select className={`bt-select${className ? ` ${className}` : ''}`} id={fieldId} {...props} />
     </label>
   )
 }

--- a/packages/dashboard/src/components/primitives/status-chip.tsx
+++ b/packages/dashboard/src/components/primitives/status-chip.tsx
@@ -13,7 +13,7 @@ export function StatusChip({ status }: StatusChipProps) {
   const tone = getStatusTone(status)
 
   return (
-    <span className={`bb-status-chip bb-status-chip--${tone}`}>
+    <span className={`bt-status-chip bt-status-chip--${tone}`}>
       {status.replaceAll('_', ' ')}
     </span>
   )

--- a/packages/dashboard/src/components/primitives/surface-card.tsx
+++ b/packages/dashboard/src/components/primitives/surface-card.tsx
@@ -16,7 +16,7 @@ export function SurfaceCard({
 }: SurfaceCardProps) {
   return (
     <div
-      className={`bb-surface-card bb-surface-card--${tone}${className ? ` ${className}` : ''}`}
+      className={`bt-surface-card bt-surface-card--${tone}${className ? ` ${className}` : ''}`}
       {...rest}
     >
       {children}

--- a/packages/dashboard/src/components/shell/public/public-shell.tsx
+++ b/packages/dashboard/src/components/shell/public/public-shell.tsx
@@ -2,9 +2,9 @@ import type { PropsWithChildren } from 'react'
 
 export function PublicShell({ children }: PropsWithChildren) {
   return (
-    <div className="bb-public-shell">
-      <div className="bb-public-shell__ghost" aria-hidden="true" />
-      <main className="bb-public-shell__canvas">{children}</main>
+    <div className="bt-public-shell">
+      <div className="bt-public-shell__ghost" aria-hidden="true" />
+      <main className="bt-public-shell__canvas">{children}</main>
     </div>
   )
 }

--- a/packages/dashboard/src/components/shell/public/public-top-bar.tsx
+++ b/packages/dashboard/src/components/shell/public/public-top-bar.tsx
@@ -2,7 +2,7 @@ import { AppWordmark } from '../../primitives/app-wordmark'
 
 export function PublicTopBar() {
   return (
-    <div className="bb-public-topbar">
+    <div className="bt-public-topbar">
       <AppWordmark centered />
     </div>
   )

--- a/packages/dashboard/src/components/shell/workbench/workbench-canvas.tsx
+++ b/packages/dashboard/src/components/shell/workbench/workbench-canvas.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from 'react'
 
 export function WorkbenchCanvas({ children }: PropsWithChildren) {
-  return <main className="bb-workbench-canvas">{children}</main>
+  return <main className="bt-workbench-canvas">{children}</main>
 }

--- a/packages/dashboard/src/components/shell/workbench/workbench-shell.tsx
+++ b/packages/dashboard/src/components/shell/workbench/workbench-shell.tsx
@@ -4,7 +4,7 @@ import { WorkbenchTopBar } from './workbench-top-bar'
 
 export function WorkbenchShell({ children }: PropsWithChildren) {
   return (
-    <div className="bb-workbench-shell">
+    <div className="bt-workbench-shell">
       <WorkbenchTopBar />
       <WorkbenchCanvas>{children}</WorkbenchCanvas>
     </div>

--- a/packages/dashboard/src/components/shell/workbench/workbench-top-bar.tsx
+++ b/packages/dashboard/src/components/shell/workbench/workbench-top-bar.tsx
@@ -11,17 +11,17 @@ export function WorkbenchTopBar() {
   const modeLabel = client.readiness.backendEnabled ? 'Live' : 'Fixtures'
 
   return (
-    <header className="bb-workbench-topbar">
-      <Button aria-label="Go back" className="bb-workbench-topbar__back" to={backTarget} variant="ghost">
+    <header className="bt-workbench-topbar">
+      <Button aria-label="Go back" className="bt-workbench-topbar__back" to={backTarget} variant="ghost">
         <span aria-hidden="true">←</span>
       </Button>
       <AppWordmark centered />
       {isDevMode ? (
-        <div className="bb-workbench-topbar__mode" aria-label={`Mode: ${modeLabel}`}>
+        <div className="bt-workbench-topbar__mode" aria-label={`Mode: ${modeLabel}`}>
           {modeLabel}
         </div>
       ) : (
-        <div className="bb-workbench-topbar__spacer" aria-hidden="true" />
+        <div className="bt-workbench-topbar__spacer" aria-hidden="true" />
       )}
     </header>
   )

--- a/packages/dashboard/src/features/backstock/components/backstock-photo-intake.tsx
+++ b/packages/dashboard/src/features/backstock/components/backstock-photo-intake.tsx
@@ -27,13 +27,13 @@ export function BackstockPhotoIntake({
   sourcePhotos,
 }: BackstockPhotoIntakeProps) {
   return (
-    <SurfaceCard className="bb-backstock-card bb-backstock-intake" tone="base">
+    <SurfaceCard className="bt-backstock-card bt-backstock-intake" tone="base">
       <BackstockPhotoIntakeHeader
         generationBlockedMessage={generationBlockedMessage}
         sourcePhotoCount={sourcePhotos.length}
       />
 
-      <div className="bb-backstock-intake__stage">
+      <div className="bt-backstock-intake__stage">
         <BackstockPhotoDropzone
           generationBlockedMessage={generationBlockedMessage}
           onPhotoFilesSelected={onPhotoFilesSelected}
@@ -51,7 +51,7 @@ export function BackstockPhotoIntake({
           sourcePhotos={sourcePhotos}
         />
       ) : (
-        <p className="bb-field__hint">
+        <p className="bt-field__hint">
           {generationBlockedMessage
             ? 'Queue one or more images now. Grouped draft generation will connect here after backend work lands.'
             : 'Queue one or more images to generate the initial grouped draft.'}
@@ -84,15 +84,15 @@ function BackstockPhotoIntakeHeader({
     : 'Stage several shelf or storage photos from one location, then generate a grouped first draft to review below.'
 
   return (
-    <div className="bb-backstock-intake__header">
+    <div className="bt-backstock-intake__header">
       <div>
-        <p className="bb-backstock-intake__eyebrow">Photo-Assisted Draft</p>
-        <h2 className="bb-backstock-card__title">Photo Staging</h2>
-        <p className="bb-backstock-card__support">{support}</p>
+        <p className="bt-backstock-intake__eyebrow">Photo-Assisted Draft</p>
+        <h2 className="bt-backstock-card__title">Photo Staging</h2>
+        <p className="bt-backstock-card__support">{support}</p>
       </div>
-      <div className="bb-backstock-intake__summary">
-        <p className="bb-backstock-intake__summary-value">{queueLabel}</p>
-        <p className="bb-backstock-intake__summary-note">
+      <div className="bt-backstock-intake__summary">
+        <p className="bt-backstock-intake__summary-value">{queueLabel}</p>
+        <p className="bt-backstock-intake__summary-note">
           Manual entry stays available if you would rather count without photos.
         </p>
       </div>
@@ -114,22 +114,22 @@ function BackstockPhotoDropzone({
     : 'Add a few wide shots of sealed bottles in one backstock area. The draft groups likely products and bottle counts before review.'
 
   return (
-    <label className="bb-backstock-intake__dropzone" htmlFor="backstock-source-photos">
+    <label className="bt-backstock-intake__dropzone" htmlFor="backstock-source-photos">
       <input
         accept="image/*"
         aria-label="Choose Photos"
-        className="bb-backstock-intake__input"
+        className="bt-backstock-intake__input"
         id="backstock-source-photos"
         multiple
         onChange={(event) => onPhotoFilesSelected(event.currentTarget.files)}
         type="file"
       />
-      <span className="bb-backstock-intake__drop-eyebrow">Choose Photos</span>
-      <span className="bb-backstock-intake__drop-title">
+      <span className="bt-backstock-intake__drop-eyebrow">Choose Photos</span>
+      <span className="bt-backstock-intake__drop-title">
         Stage shelf photos for the first draft
       </span>
-      <span className="bb-backstock-intake__drop-support">{support}</span>
-      <span className="bb-backstock-intake__drop-action">
+      <span className="bt-backstock-intake__drop-support">{support}</span>
+      <span className="bt-backstock-intake__drop-action">
         {sourcePhotoCount > 0 ? 'Add More Photos' : 'Choose Photos'}
       </span>
     </label>
@@ -161,13 +161,13 @@ function BackstockPhotoWorkflow({
   ]
 
   return (
-    <ol className="bb-backstock-intake__workflow">
+    <ol className="bt-backstock-intake__workflow">
       {steps.map((step, index) => (
         <li key={step.title}>
-          <span className="bb-backstock-intake__workflow-step">{index + 1}</span>
+          <span className="bt-backstock-intake__workflow-step">{index + 1}</span>
           <div>
-            <p className="bb-backstock-intake__workflow-title">{step.title}</p>
-            <p className="bb-backstock-intake__workflow-copy">{step.copy}</p>
+            <p className="bt-backstock-intake__workflow-title">{step.title}</p>
+            <p className="bt-backstock-intake__workflow-copy">{step.copy}</p>
           </div>
         </li>
       ))}
@@ -183,7 +183,7 @@ function BackstockPhotoTray({
   sourcePhotos: BackstockSourcePhoto[]
 }) {
   return (
-    <div aria-label="Selected source photos" className="bb-backstock-photo-tray">
+    <div aria-label="Selected source photos" className="bt-backstock-photo-tray">
       {sourcePhotos.map((sourcePhoto, index) => (
         <BackstockPhotoTrayCard
           index={index}
@@ -206,27 +206,27 @@ function BackstockPhotoTrayCard({
   sourcePhoto: BackstockSourcePhoto
 }) {
   return (
-    <div className="bb-backstock-photo-card">
-      <div className="bb-backstock-photo-card__preview">
-        <div className="bb-backstock-photo-card__placeholder">
-          <p className="bb-backstock-photo-card__placeholder-step">
+    <div className="bt-backstock-photo-card">
+      <div className="bt-backstock-photo-card__preview">
+        <div className="bt-backstock-photo-card__placeholder">
+          <p className="bt-backstock-photo-card__placeholder-step">
             Frame {String(index + 1).padStart(2, '0')}
           </p>
-          <p className="bb-backstock-photo-card__placeholder-note">
+          <p className="bt-backstock-photo-card__placeholder-note">
             {sourcePhoto.file ? 'Queued for draft generation' : 'Restored draft'}
           </p>
         </div>
         <button
-          className="bb-backstock-photo-card__remove"
+          className="bt-backstock-photo-card__remove"
           onClick={() => onRemoveSourcePhoto(sourcePhoto.id)}
           type="button"
         >
           Remove
         </button>
       </div>
-      <div className="bb-backstock-photo-card__body">
-        <p className="bb-backstock-photo-card__name">{sourcePhoto.name}</p>
-        <p className="bb-backstock-photo-card__meta">
+      <div className="bt-backstock-photo-card__body">
+        <p className="bt-backstock-photo-card__name">{sourcePhoto.name}</p>
+        <p className="bt-backstock-photo-card__meta">
           {formatBytes(sourcePhoto.sizeBytes)}
           {sourcePhoto.file === null ? ' • restored from this browser session' : ''}
         </p>
@@ -251,9 +251,9 @@ function BackstockPhotoActions({
   onGenerateDraft: () => void
 }) {
   return (
-    <div className="bb-backstock-intake__actions">
-      <div className="bb-backstock-intake__actions-copy">
-        <p className="bb-backstock-intake__actions-title">
+    <div className="bt-backstock-intake__actions">
+      <div className="bt-backstock-intake__actions-copy">
+        <p className="bt-backstock-intake__actions-title">
           {generationBlockedMessage
             ? 'Photo-generated drafts are pending backend support.'
             : hasGeneratedDraft
@@ -261,15 +261,15 @@ function BackstockPhotoActions({
             : 'Generate a grouped first pass when the queue looks right.'}
         </p>
         {generationBlockedMessage ? (
-          <p aria-live="polite" className="bb-field__hint bb-field__hint--warning">
+          <p aria-live="polite" className="bt-field__hint bt-field__hint--warning">
             {generationBlockedMessage}
           </p>
         ) : needsDraftRegeneration ? (
-          <p aria-live="polite" className="bb-field__hint bb-field__hint--warning">
+          <p aria-live="polite" className="bt-field__hint bt-field__hint--warning">
             Source photos changed. Regenerate the draft before submitting.
           </p>
         ) : (
-          <p className="bb-field__hint">
+          <p className="bt-field__hint">
             Photos are optional, but they are always part of the initial draft flow when
             you use them.
           </p>

--- a/packages/dashboard/src/features/backstock/components/backstock-report-create-parts.tsx
+++ b/packages/dashboard/src/features/backstock/components/backstock-report-create-parts.tsx
@@ -26,9 +26,9 @@ export function BackstockLineItemEditor({
   const selectedBottleLabel = lineItem.selectedBottle?.name ?? `Line item ${index + 1}`
 
   return (
-    <div className="bb-backstock-line-item">
-      <div className="bb-backstock-line-item__meta">
-        <p className="bb-backstock-line-item__eyebrow">
+    <div className="bt-backstock-line-item">
+      <div className="bt-backstock-line-item__meta">
+        <p className="bt-backstock-line-item__eyebrow">
           {lineItem.origin === 'generated' ? 'Generated Suggestion' : 'Manual Entry'}
         </p>
         <Button onPress={() => onRemoveLineItem(lineItem.id)} variant="ghost">
@@ -36,7 +36,7 @@ export function BackstockLineItemEditor({
         </Button>
       </div>
 
-      <div className="bb-backstock-line-item__fields">
+      <div className="bt-backstock-line-item__fields">
         <ReportBottleMatchField
           emptyHint="Search by product name to add the right bottle."
           inputId={`${lineItem.id}-product`}
@@ -49,10 +49,10 @@ export function BackstockLineItemEditor({
           selectedBottleId={lineItem.selectedBottle?.id ?? null}
         />
 
-        <label className="bb-field" htmlFor={quantityInputId}>
-          <span className="bb-field__label">Full Bottles</span>
+        <label className="bt-field" htmlFor={quantityInputId}>
+          <span className="bt-field__label">Full Bottles</span>
           <input
-            className="bb-input"
+            className="bt-input"
             id={quantityInputId}
             inputMode="numeric"
             min={0}
@@ -63,7 +63,7 @@ export function BackstockLineItemEditor({
             type="number"
             value={lineItem.quantityFullBottles}
           />
-          <p className="bb-field__hint">
+          <p className="bt-field__hint">
             {lineItem.selectedBottle
               ? `${selectedBottleLabel} is counted as sealed and full.`
               : 'Choose a product before submitting this line item.'}
@@ -94,22 +94,22 @@ export function BackstockSummaryGrid({
   totalBottleCount: number
 }) {
   return (
-    <div className="bb-backstock-summary-grid">
+    <div className="bt-backstock-summary-grid">
       <div>
-        <p className="bb-backstock-stat__label">Location</p>
-        <p className="bb-backstock-stat__value">{locationName}</p>
+        <p className="bt-backstock-stat__label">Location</p>
+        <p className="bt-backstock-stat__value">{locationName}</p>
       </div>
       <div>
-        <p className="bb-backstock-stat__label">Products</p>
-        <p className="bb-backstock-stat__value">{productCount}</p>
+        <p className="bt-backstock-stat__label">Products</p>
+        <p className="bt-backstock-stat__value">{productCount}</p>
       </div>
       <div>
-        <p className="bb-backstock-stat__label">Full Bottles</p>
-        <p className="bb-backstock-stat__value">{totalBottleCount}</p>
+        <p className="bt-backstock-stat__label">Full Bottles</p>
+        <p className="bt-backstock-stat__value">{totalBottleCount}</p>
       </div>
       <div>
-        <p className="bb-backstock-stat__label">Source Photos</p>
-        <p className="bb-backstock-stat__value">{sourcePhotoCount}</p>
+        <p className="bt-backstock-stat__label">Source Photos</p>
+        <p className="bt-backstock-stat__value">{sourcePhotoCount}</p>
       </div>
     </div>
   )

--- a/packages/dashboard/src/features/backstock/components/backstock-report-create-screen.tsx
+++ b/packages/dashboard/src/features/backstock/components/backstock-report-create-screen.tsx
@@ -104,7 +104,7 @@ export function BackstockReportCreateScreen({
   }
 
   return (
-    <div className="bb-backstock-screen">
+    <div className="bt-backstock-screen">
       <BackstockReportHeader
         support="Count sealed bottles in one backstock location. Start from photos or enter line items directly."
         title="New Backstock Report"
@@ -116,13 +116,13 @@ export function BackstockReportCreateScreen({
         submissionBlocked={!!submissionBlockedMessage}
       />
       {integrationNotice ? (
-        <SurfaceCard className="bb-message-panel" tone="low">
-          <p className="bb-message-panel__body">{integrationNotice}</p>
+        <SurfaceCard className="bt-message-panel" tone="low">
+          <p className="bt-message-panel__body">{integrationNotice}</p>
         </SurfaceCard>
       ) : null}
       {draftStatusMessage ? (
-        <SurfaceCard className="bb-message-panel" tone="low">
-          <p aria-live="polite" className="bb-message-panel__body">
+        <SurfaceCard className="bt-message-panel" tone="low">
+          <p aria-live="polite" className="bt-message-panel__body">
             {draftStatusMessage}
           </p>
         </SurfaceCard>
@@ -203,17 +203,17 @@ function BackstockWorkflowRail({
   ]
 
   return (
-    <ol className="bb-backstock-workflow" aria-label="Backstock report workflow">
+    <ol className="bt-backstock-workflow" aria-label="Backstock report workflow">
       {steps.map((step, index) => {
         const state =
           index < currentStage ? 'complete' : index === currentStage ? 'active' : 'upcoming'
 
         return (
-          <li className={`bb-backstock-workflow__step is-${state}`} key={step.label}>
-            <div className="bb-backstock-workflow__marker">{index + 1}</div>
+          <li className={`bt-backstock-workflow__step is-${state}`} key={step.label}>
+            <div className="bt-backstock-workflow__marker">{index + 1}</div>
             <div>
-              <p className="bb-backstock-workflow__label">{step.label}</p>
-              <p className="bb-backstock-workflow__support">{step.support}</p>
+              <p className="bt-backstock-workflow__label">{step.label}</p>
+              <p className="bt-backstock-workflow__support">{step.support}</p>
             </div>
           </li>
         )
@@ -230,10 +230,10 @@ function BackstockReportHeader({
   title: string
 }) {
   return (
-    <section className="bb-backstock-header">
-      <p className="bb-backstock-header__eyebrow">Reports</p>
-      <h1 className="bb-page-title">{title}</h1>
-      <p className="bb-reports-header__support">{support}</p>
+    <section className="bt-backstock-header">
+      <p className="bt-backstock-header__eyebrow">Reports</p>
+      <h1 className="bt-page-title">{title}</h1>
+      <p className="bt-reports-header__support">{support}</p>
     </section>
   )
 }
@@ -250,13 +250,13 @@ function BackstockSubmittedState({
   submittedSummary: SubmittedBackstockSummary
 }) {
   return (
-    <div className="bb-backstock-screen">
+    <div className="bt-backstock-screen">
       <BackstockReportHeader
         support="Fixture mode keeps this submitted snapshot in the current browser session for flow review."
         title="Backstock Report Submitted"
       />
 
-      <SurfaceCard className="bb-backstock-card bb-backstock-card--summary" tone="low">
+      <SurfaceCard className="bt-backstock-card bt-backstock-card--summary" tone="low">
         <BackstockSummaryGrid
           locationName={locationName}
           productCount={submittedSummary.skuCount}
@@ -264,23 +264,23 @@ function BackstockSubmittedState({
           totalBottleCount={submittedSummary.totalBottleCount}
         />
 
-        <div className="bb-backstock-submitted-list" aria-label="Submitted line items">
+        <div className="bt-backstock-submitted-list" aria-label="Submitted line items">
           {submittedSummary.lineItems.map((lineItem) => (
-            <div className="bb-backstock-submitted-row" key={lineItem.bottle.id}>
+            <div className="bt-backstock-submitted-row" key={lineItem.bottle.id}>
               <div>
-                <p className="bb-backstock-submitted-row__name">{lineItem.bottle.name}</p>
-                <p className="bb-backstock-submitted-row__meta">
+                <p className="bt-backstock-submitted-row__name">{lineItem.bottle.name}</p>
+                <p className="bt-backstock-submitted-row__meta">
                   {buildBottleMeta(lineItem.bottle)}
                 </p>
               </div>
-              <p className="bb-backstock-submitted-row__count">
+              <p className="bt-backstock-submitted-row__count">
                 {lineItem.quantityFullBottles}
               </p>
             </div>
           ))}
         </div>
 
-        <div className="bb-backstock-card__actions">
+        <div className="bt-backstock-card__actions">
           <Button onPress={onStartAnotherReport} variant="secondary">
             Start Another Report
           </Button>
@@ -305,17 +305,17 @@ function BackstockSetupCard({
   startMode: BackstockStartMode
 }) {
   return (
-    <SurfaceCard className="bb-backstock-card" tone="low">
-      <div className="bb-backstock-card__heading">
+    <SurfaceCard className="bt-backstock-card" tone="low">
+      <div className="bt-backstock-card__heading">
         <div>
-          <h2 className="bb-backstock-card__title">Report Setup</h2>
-          <p className="bb-backstock-card__support">
+          <h2 className="bt-backstock-card__title">Report Setup</h2>
+          <p className="bt-backstock-card__support">
             Choose one location and the fastest starting point for this count.
           </p>
         </div>
       </div>
 
-      <div className="bb-backstock-setup-grid">
+      <div className="bt-backstock-setup-grid">
         <Select
           label="Backstock Location"
           onChange={(event) => onLocationChange(event.currentTarget.value)}
@@ -329,12 +329,12 @@ function BackstockSetupCard({
           ))}
         </Select>
 
-        <div className="bb-field">
-          <span className="bb-field__label">How To Start</span>
-          <div className="bb-backstock-mode-toggle" role="group" aria-label="How To Start">
+        <div className="bt-field">
+          <span className="bt-field__label">How To Start</span>
+          <div className="bt-backstock-mode-toggle" role="group" aria-label="How To Start">
             <button
               aria-pressed={startMode === 'photo'}
-              className={`bb-backstock-mode-toggle__option${startMode === 'photo' ? ' is-active' : ''}`}
+              className={`bt-backstock-mode-toggle__option${startMode === 'photo' ? ' is-active' : ''}`}
               onClick={() => onStartModeChange('photo')}
               type="button"
             >
@@ -342,7 +342,7 @@ function BackstockSetupCard({
             </button>
             <button
               aria-pressed={startMode === 'manual'}
-              className={`bb-backstock-mode-toggle__option${startMode === 'manual' ? ' is-active' : ''}`}
+              className={`bt-backstock-mode-toggle__option${startMode === 'manual' ? ' is-active' : ''}`}
               onClick={() => onStartModeChange('manual')}
               type="button"
             >
@@ -375,11 +375,11 @@ function BackstockLineItemsCard({
   startMode: BackstockStartMode
 }) {
   return (
-    <SurfaceCard className="bb-backstock-card" tone="low">
-      <div className="bb-backstock-card__heading">
+    <SurfaceCard className="bt-backstock-card" tone="low">
+      <div className="bt-backstock-card__heading">
         <div>
-          <h2 className="bb-backstock-card__title">Line Items</h2>
-          <p className="bb-backstock-card__support">
+          <h2 className="bt-backstock-card__title">Line Items</h2>
+          <p className="bt-backstock-card__support">
             Review grouped counts, fix product matches, and add anything the draft missed.
           </p>
         </div>
@@ -389,7 +389,7 @@ function BackstockLineItemsCard({
       </div>
 
       {lineItems.length > 0 ? (
-        <div className="bb-backstock-line-items">
+        <div className="bt-backstock-line-items">
           {lineItems.map((lineItem, index) => (
             <BackstockLineItemEditor
               index={index}
@@ -404,8 +404,8 @@ function BackstockLineItemsCard({
           ))}
         </div>
       ) : (
-        <SurfaceCard className="bb-backstock-empty-state" tone="canvas">
-          <p className="bb-empty-state__body">
+        <SurfaceCard className="bt-backstock-empty-state" tone="canvas">
+          <p className="bt-empty-state__body">
             {startMode === 'photo'
               ? 'Generate a draft from source photos or add a product manually to begin.'
               : 'Add the first product line item to begin the backstock snapshot.'}
@@ -436,11 +436,11 @@ function BackstockSummaryCard({
   submitDisabled: boolean
 }) {
   return (
-    <SurfaceCard className="bb-backstock-card" tone="base">
-      <div className="bb-backstock-card__heading">
+    <SurfaceCard className="bt-backstock-card" tone="base">
+      <div className="bt-backstock-card__heading">
         <div>
-          <h2 className="bb-backstock-card__title">Snapshot Summary</h2>
-          <p className="bb-backstock-card__support">
+          <h2 className="bt-backstock-card__title">Snapshot Summary</h2>
+          <p className="bt-backstock-card__support">
             {submissionBlockedMessage
               ? 'Finalize the snapshot details now. Live submission will connect here after backend support lands.'
               : 'Submit once the grouped counts reflect what is sealed and on hand right now.'}
@@ -455,18 +455,18 @@ function BackstockSummaryCard({
         totalBottleCount={draftSummary.totalBottleCount}
       />
 
-      <div className="bb-backstock-card__actions">
-        <div className="bb-backstock-card__actions-copy">
+      <div className="bt-backstock-card__actions">
+        <div className="bt-backstock-card__actions-copy">
           {submissionBlockedMessage ? (
-            <p aria-live="polite" className="bb-field__hint bb-field__hint--warning">
+            <p aria-live="polite" className="bt-field__hint bt-field__hint--warning">
               {submissionBlockedMessage}
             </p>
           ) : needsDraftRegeneration ? (
-            <p aria-live="polite" className="bb-field__hint bb-field__hint--warning">
+            <p aria-live="polite" className="bt-field__hint bt-field__hint--warning">
               Regenerate the draft to match the current photo set before submitting.
             </p>
           ) : submissionReadinessMessage ? (
-            <p aria-live="polite" className="bb-field__hint bb-field__hint--warning">
+            <p aria-live="polite" className="bt-field__hint bt-field__hint--warning">
               {submissionReadinessMessage}
             </p>
           ) : null}

--- a/packages/dashboard/src/features/backstock/routes/backstock-report-create-route.tsx
+++ b/packages/dashboard/src/features/backstock/routes/backstock-report-create-route.tsx
@@ -56,19 +56,19 @@ function ResolvedBackstockReportCreateRoute({
 
 function BackstockRouteLoadingScreen() {
   return (
-    <div className="bb-backstock-screen">
-      <section className="bb-backstock-header">
-        <p className="bb-backstock-header__eyebrow">Reports</p>
-        <h1 className="bb-page-title">New Backstock Report</h1>
-        <p className="bb-reports-header__support">
+    <div className="bt-backstock-screen">
+      <section className="bt-backstock-header">
+        <p className="bt-backstock-header__eyebrow">Reports</p>
+        <h1 className="bt-page-title">New Backstock Report</h1>
+        <p className="bt-reports-header__support">
           Count sealed bottles in one backstock location. Start from photos or enter line
           items directly.
         </p>
       </section>
 
-      <SurfaceCard className="bb-loading-panel" tone="low">
-        <p className="bb-loading-panel__eyebrow">Backstock</p>
-        <p className="bb-loading-panel__body">Loading available locations.</p>
+      <SurfaceCard className="bt-loading-panel" tone="low">
+        <p className="bt-loading-panel__eyebrow">Backstock</p>
+        <p className="bt-loading-panel__body">Loading available locations.</p>
       </SurfaceCard>
     </div>
   )
@@ -82,15 +82,15 @@ function BackstockLocationsUnavailableScreen({
   onRetry: () => void
 }) {
   return (
-    <section className="bb-centered-state">
-      <div className="bb-centered-state__icon bb-centered-state__icon--blocked" aria-hidden="true">
-        <span className="bb-centered-state__icon-core" />
-        <span className="bb-centered-state__icon-dot" />
-        <span className="bb-centered-state__icon-slash" />
+    <section className="bt-centered-state">
+      <div className="bt-centered-state__icon bt-centered-state__icon--blocked" aria-hidden="true">
+        <span className="bt-centered-state__icon-core" />
+        <span className="bt-centered-state__icon-dot" />
+        <span className="bt-centered-state__icon-slash" />
       </div>
-      <h1 className="bb-centered-state__title">Backstock Locations Unavailable</h1>
-      <p className="bb-centered-state__body">{errorMessage}</p>
-      <div className="bb-centered-state__actions">
+      <h1 className="bt-centered-state__title">Backstock Locations Unavailable</h1>
+      <p className="bt-centered-state__body">{errorMessage}</p>
+      <div className="bt-centered-state__actions">
         <Button onPress={onRetry} variant="secondary">
           Retry
         </Button>

--- a/packages/dashboard/src/features/backstock/styles/backstock-report.css
+++ b/packages/dashboard/src/features/backstock/styles/backstock-report.css
@@ -1,44 +1,44 @@
-.bb-backstock-screen,
-.bb-backstock-header,
-.bb-backstock-card,
-.bb-backstock-empty-state,
-.bb-backstock-workflow,
-.bb-backstock-workflow__step,
-.bb-backstock-card__heading,
-.bb-backstock-card__actions,
-.bb-backstock-line-item__meta,
-.bb-backstock-submitted-row,
-.bb-backstock-intake,
-.bb-backstock-intake__header,
-.bb-backstock-intake__stage,
-.bb-backstock-intake__workflow,
-.bb-backstock-intake__workflow li,
-.bb-backstock-intake__actions,
-.bb-backstock-photo-card,
-.bb-backstock-photo-card__preview,
-.bb-backstock-photo-card__body,
-.bb-backstock-line-item {
+.bt-backstock-screen,
+.bt-backstock-header,
+.bt-backstock-card,
+.bt-backstock-empty-state,
+.bt-backstock-workflow,
+.bt-backstock-workflow__step,
+.bt-backstock-card__heading,
+.bt-backstock-card__actions,
+.bt-backstock-line-item__meta,
+.bt-backstock-submitted-row,
+.bt-backstock-intake,
+.bt-backstock-intake__header,
+.bt-backstock-intake__stage,
+.bt-backstock-intake__workflow,
+.bt-backstock-intake__workflow li,
+.bt-backstock-intake__actions,
+.bt-backstock-photo-card,
+.bt-backstock-photo-card__preview,
+.bt-backstock-photo-card__body,
+.bt-backstock-line-item {
   display: flex;
 }
 
-.bb-backstock-screen {
+.bt-backstock-screen {
   flex-direction: column;
   gap: var(--space-4xl);
 }
 
-.bb-backstock-header {
+.bt-backstock-header {
   flex-direction: column;
   gap: var(--space-md);
 }
 
-.bb-backstock-header__eyebrow,
-.bb-backstock-line-item__eyebrow,
-.bb-backstock-stat__label,
-.bb-backstock-workflow__label,
-.bb-backstock-intake__eyebrow,
-.bb-backstock-intake__workflow-title,
-.bb-backstock-intake__drop-eyebrow,
-.bb-backstock-photo-card__placeholder-step {
+.bt-backstock-header__eyebrow,
+.bt-backstock-line-item__eyebrow,
+.bt-backstock-stat__label,
+.bt-backstock-workflow__label,
+.bt-backstock-intake__eyebrow,
+.bt-backstock-intake__workflow-title,
+.bt-backstock-intake__drop-eyebrow,
+.bt-backstock-photo-card__placeholder-step {
   margin: 0;
   font-family: var(--font-label);
   font-size: var(--type-label-size);
@@ -46,43 +46,43 @@
   text-transform: uppercase;
 }
 
-.bb-backstock-header__eyebrow,
-.bb-backstock-line-item__eyebrow,
-.bb-backstock-stat__label {
+.bt-backstock-header__eyebrow,
+.bt-backstock-line-item__eyebrow,
+.bt-backstock-stat__label {
   color: var(--color-text-muted);
 }
 
-.bb-backstock-workflow__label,
-.bb-backstock-intake__eyebrow,
-.bb-backstock-intake__workflow-title,
-.bb-backstock-intake__drop-eyebrow {
+.bt-backstock-workflow__label,
+.bt-backstock-intake__eyebrow,
+.bt-backstock-intake__workflow-title,
+.bt-backstock-intake__drop-eyebrow {
   color: var(--color-text-secondary);
 }
 
-.bb-backstock-card,
-.bb-backstock-empty-state,
-.bb-backstock-intake__workflow {
+.bt-backstock-card,
+.bt-backstock-empty-state,
+.bt-backstock-intake__workflow {
   flex-direction: column;
   gap: var(--space-2xl);
 }
 
-.bb-backstock-card,
-.bb-backstock-empty-state {
+.bt-backstock-card,
+.bt-backstock-empty-state {
   padding: var(--space-3xl);
 }
 
-.bb-backstock-card--summary {
+.bt-backstock-card--summary {
   gap: var(--space-3xl);
 }
 
-.bb-backstock-workflow {
+.bt-backstock-workflow {
   gap: var(--space-lg);
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.bb-backstock-workflow__step {
+.bt-backstock-workflow__step {
   flex: 1 1 0;
   gap: var(--space-lg);
   align-items: start;
@@ -90,8 +90,8 @@
   border-top: 1px solid var(--color-border-subtle);
 }
 
-.bb-backstock-workflow__marker,
-.bb-backstock-intake__workflow-step {
+.bt-backstock-workflow__marker,
+.bt-backstock-intake__workflow-step {
   display: inline-flex;
   width: 28px;
   height: 28px;
@@ -106,81 +106,81 @@
   flex: 0 0 auto;
 }
 
-.bb-backstock-workflow__step.is-active .bb-backstock-workflow__marker,
-.bb-backstock-workflow__step.is-complete .bb-backstock-workflow__marker,
-.bb-backstock-intake__workflow-step {
+.bt-backstock-workflow__step.is-active .bt-backstock-workflow__marker,
+.bt-backstock-workflow__step.is-complete .bt-backstock-workflow__marker,
+.bt-backstock-intake__workflow-step {
   border-color: var(--color-accent);
   color: var(--color-accent-soft);
 }
 
-.bb-backstock-workflow__support,
-.bb-backstock-card__support,
-.bb-backstock-submitted-row__meta,
-.bb-backstock-intake__summary-note,
-.bb-backstock-intake__workflow-copy,
-.bb-backstock-intake__drop-support,
-.bb-backstock-photo-card__meta,
-.bb-backstock-photo-card__placeholder-note,
-.bb-backstock-intake__actions-title {
+.bt-backstock-workflow__support,
+.bt-backstock-card__support,
+.bt-backstock-submitted-row__meta,
+.bt-backstock-intake__summary-note,
+.bt-backstock-intake__workflow-copy,
+.bt-backstock-intake__drop-support,
+.bt-backstock-photo-card__meta,
+.bt-backstock-photo-card__placeholder-note,
+.bt-backstock-intake__actions-title {
   margin: var(--space-sm) 0 0;
   color: var(--color-text-muted);
   line-height: 1.5;
 }
 
-.bb-backstock-workflow__step.is-active .bb-backstock-workflow__label,
-.bb-backstock-workflow__step.is-complete .bb-backstock-workflow__label {
+.bt-backstock-workflow__step.is-active .bt-backstock-workflow__label,
+.bt-backstock-workflow__step.is-complete .bt-backstock-workflow__label {
   color: var(--color-text-primary);
 }
 
-.bb-backstock-workflow__step.is-upcoming .bb-backstock-workflow__support {
+.bt-backstock-workflow__step.is-upcoming .bt-backstock-workflow__support {
   color: var(--color-text-muted-soft);
 }
 
-.bb-backstock-card__heading,
-.bb-backstock-card__actions,
-.bb-backstock-line-item__meta,
-.bb-backstock-submitted-row,
-.bb-backstock-intake__header,
-.bb-backstock-intake__stage,
-.bb-backstock-intake__actions {
+.bt-backstock-card__heading,
+.bt-backstock-card__actions,
+.bt-backstock-line-item__meta,
+.bt-backstock-submitted-row,
+.bt-backstock-intake__header,
+.bt-backstock-intake__stage,
+.bt-backstock-intake__actions {
   align-items: start;
   justify-content: space-between;
   gap: var(--space-lg);
 }
 
-.bb-backstock-card__title,
-.bb-backstock-submitted-row__name,
-.bb-backstock-intake__drop-title {
+.bt-backstock-card__title,
+.bt-backstock-submitted-row__name,
+.bt-backstock-intake__drop-title {
   margin: 0;
   font-family: var(--font-display);
   font-weight: 400;
   color: var(--color-text-primary);
 }
 
-.bb-backstock-card__title,
-.bb-backstock-submitted-row__name {
+.bt-backstock-card__title,
+.bt-backstock-submitted-row__name {
   font-size: 28px;
 }
 
-.bb-backstock-intake__drop-title {
+.bt-backstock-intake__drop-title {
   font-size: 32px;
   line-height: 1.05;
 }
 
-.bb-backstock-setup-grid,
-.bb-backstock-line-item__fields,
-.bb-backstock-summary-grid,
-.bb-backstock-photo-tray {
+.bt-backstock-setup-grid,
+.bt-backstock-line-item__fields,
+.bt-backstock-summary-grid,
+.bt-backstock-photo-tray {
   display: grid;
 }
 
-.bb-backstock-setup-grid,
-.bb-backstock-line-item__fields {
+.bt-backstock-setup-grid,
+.bt-backstock-line-item__fields {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-xl);
 }
 
-.bb-backstock-mode-toggle {
+.bt-backstock-mode-toggle {
   display: inline-flex;
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-lg);
@@ -188,7 +188,7 @@
   overflow: hidden;
 }
 
-.bb-backstock-mode-toggle__option {
+.bt-backstock-mode-toggle__option {
   border: 0;
   background: transparent;
   color: var(--color-text-muted);
@@ -203,28 +203,28 @@
     color 160ms ease;
 }
 
-.bb-backstock-mode-toggle__option.is-active {
+.bt-backstock-mode-toggle__option.is-active {
   background: var(--color-surface-high);
   color: var(--color-accent-soft);
 }
 
-.bb-backstock-mode-toggle__option:focus-visible {
+.bt-backstock-mode-toggle__option:focus-visible {
   outline: 2px solid var(--color-accent-soft);
   outline-offset: 2px;
 }
 
-.bb-backstock-intake {
+.bt-backstock-intake {
   gap: var(--space-3xl);
 }
 
-.bb-backstock-intake__summary {
+.bt-backstock-intake__summary {
   max-width: 280px;
   text-align: right;
 }
 
-.bb-backstock-intake__summary-value,
-.bb-backstock-submitted-row__count,
-.bb-backstock-stat__value {
+.bt-backstock-intake__summary-value,
+.bt-backstock-submitted-row__count,
+.bt-backstock-stat__value {
   margin: 0;
   font-family: var(--font-display);
   font-variant-numeric: tabular-nums;
@@ -232,16 +232,16 @@
   color: var(--color-text-primary);
 }
 
-.bb-backstock-intake__summary-value {
+.bt-backstock-intake__summary-value {
   font-size: 34px;
 }
 
-.bb-backstock-intake__stage,
-.bb-backstock-intake__actions {
+.bt-backstock-intake__stage,
+.bt-backstock-intake__actions {
   gap: var(--space-2xl);
 }
 
-.bb-backstock-intake__dropzone {
+.bt-backstock-intake__dropzone {
   position: relative;
   display: flex;
   min-height: 240px;
@@ -264,11 +264,11 @@
   cursor: pointer;
 }
 
-.bb-backstock-intake__dropzone:hover {
+.bt-backstock-intake__dropzone:hover {
   border-color: var(--color-accent);
 }
 
-.bb-backstock-intake__input {
+.bt-backstock-intake__input {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -277,12 +277,12 @@
   cursor: pointer;
 }
 
-.bb-backstock-intake__input:focus-visible {
+.bt-backstock-intake__input:focus-visible {
   outline: 2px solid var(--color-accent-soft);
   outline-offset: -2px;
 }
 
-.bb-backstock-intake__drop-action {
+.bt-backstock-intake__drop-action {
   display: inline-flex;
   align-self: start;
   margin-top: var(--space-md);
@@ -296,7 +296,7 @@
   text-transform: uppercase;
 }
 
-.bb-backstock-intake__workflow {
+.bt-backstock-intake__workflow {
   min-width: 260px;
   flex: 0 0 300px;
   padding: var(--space-2xl);
@@ -307,17 +307,17 @@
   list-style: none;
 }
 
-.bb-backstock-intake__workflow li {
+.bt-backstock-intake__workflow li {
   gap: var(--space-lg);
   align-items: start;
 }
 
-.bb-backstock-photo-tray {
+.bt-backstock-photo-tray {
   grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
   gap: var(--space-lg);
 }
 
-.bb-backstock-photo-card {
+.bt-backstock-photo-card {
   flex-direction: column;
   overflow: hidden;
   border: 1px solid var(--color-border-subtle);
@@ -325,7 +325,7 @@
   background: var(--color-bg-canvas);
 }
 
-.bb-backstock-photo-card__preview {
+.bt-backstock-photo-card__preview {
   position: relative;
   min-height: 160px;
   align-items: stretch;
@@ -339,13 +339,13 @@
     var(--color-surface-base);
 }
 
-.bb-backstock-photo-card__image {
+.bt-backstock-photo-card__image {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.bb-backstock-photo-card__placeholder {
+.bt-backstock-photo-card__placeholder {
   display: flex;
   width: 100%;
   flex-direction: column;
@@ -354,15 +354,15 @@
   padding: var(--space-lg);
 }
 
-.bb-backstock-photo-card__placeholder-step {
+.bt-backstock-photo-card__placeholder-step {
   color: var(--color-accent-soft);
 }
 
-.bb-backstock-photo-card__placeholder-note {
+.bt-backstock-photo-card__placeholder-note {
   margin: 0;
 }
 
-.bb-backstock-photo-card__remove {
+.bt-backstock-photo-card__remove {
   position: absolute;
   top: var(--space-md);
   right: var(--space-md);
@@ -378,44 +378,44 @@
   cursor: pointer;
 }
 
-.bb-backstock-photo-card__remove:focus-visible {
+.bt-backstock-photo-card__remove:focus-visible {
   outline: 2px solid var(--color-accent-soft);
   outline-offset: 2px;
 }
 
-.bb-backstock-photo-card__body {
+.bt-backstock-photo-card__body {
   flex-direction: column;
   gap: var(--space-sm);
   padding: var(--space-lg);
 }
 
-.bb-backstock-photo-card__name {
+.bt-backstock-photo-card__name {
   margin: 0;
   font-size: var(--type-body-size);
   font-weight: 600;
   color: var(--color-text-primary);
 }
 
-.bb-backstock-line-items,
-.bb-backstock-submitted-list {
+.bt-backstock-line-items,
+.bt-backstock-submitted-list {
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
 }
 
-.bb-backstock-submitted-row {
+.bt-backstock-submitted-row {
   padding: var(--space-lg);
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-lg);
   background: var(--color-bg-canvas);
 }
 
-.bb-backstock-submitted-row__count,
-.bb-backstock-stat__value {
+.bt-backstock-submitted-row__count,
+.bt-backstock-stat__value {
   font-size: 30px;
 }
 
-.bb-backstock-line-item {
+.bt-backstock-line-item {
   flex-direction: column;
   gap: var(--space-xl);
   padding: var(--space-2xl);
@@ -424,51 +424,51 @@
   background: var(--color-surface-base);
 }
 
-.bb-backstock-summary-grid {
+.bt-backstock-summary-grid {
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: var(--space-xl);
 }
 
-.bb-backstock-card__actions-copy,
-.bb-backstock-intake__actions-copy {
+.bt-backstock-card__actions-copy,
+.bt-backstock-intake__actions-copy {
   flex: 1 1 auto;
 }
 
-.bb-field__hint--warning {
+.bt-field__hint--warning {
   color: var(--color-accent-soft);
 }
 
 @media (max-width: 900px) {
-  .bb-backstock-workflow,
-  .bb-backstock-card__heading,
-  .bb-backstock-card__actions,
-  .bb-backstock-line-item__meta,
-  .bb-backstock-submitted-row,
-  .bb-backstock-intake__header,
-  .bb-backstock-intake__stage,
-  .bb-backstock-intake__actions {
+  .bt-backstock-workflow,
+  .bt-backstock-card__heading,
+  .bt-backstock-card__actions,
+  .bt-backstock-line-item__meta,
+  .bt-backstock-submitted-row,
+  .bt-backstock-intake__header,
+  .bt-backstock-intake__stage,
+  .bt-backstock-intake__actions {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .bb-backstock-intake__summary {
+  .bt-backstock-intake__summary {
     max-width: none;
     text-align: left;
   }
 
-  .bb-backstock-intake__workflow {
+  .bt-backstock-intake__workflow {
     min-width: 0;
     flex-basis: auto;
   }
 
-  .bb-backstock-setup-grid,
-  .bb-backstock-line-item__fields,
-  .bb-backstock-summary-grid,
-  .bb-backstock-photo-tray {
+  .bt-backstock-setup-grid,
+  .bt-backstock-line-item__fields,
+  .bt-backstock-summary-grid,
+  .bt-backstock-photo-tray {
     grid-template-columns: 1fr;
   }
 
-  .bb-backstock-submitted-row__count {
+  .bt-backstock-submitted-row__count {
     font-size: 24px;
   }
 }

--- a/packages/dashboard/src/features/reports/components/entry-screen.tsx
+++ b/packages/dashboard/src/features/reports/components/entry-screen.tsx
@@ -3,22 +3,22 @@ import { AppWordmark } from '../../../components/primitives/app-wordmark'
 
 export function EntryScreen() {
   return (
-    <section className="bb-entry">
+    <section className="bt-entry">
       <AppWordmark centered />
 
-      <div className="bb-entry__copy">
-        <h1 className="bb-entry__headline">Reports Workbench</h1>
-        <p className="bb-entry__support">
+      <div className="bt-entry__copy">
+        <h1 className="bt-entry__headline">Reports Workbench</h1>
+        <p className="bt-entry__support">
           Open recent reports and inspect records from desktop.
         </p>
       </div>
 
-      <div className="bb-entry__actions">
+      <div className="bt-entry__actions">
         <Button to="/reports" variant="primary">
           <span>Open Reports</span>
           <span aria-hidden="true">→</span>
         </Button>
-        <p className="bb-entry__note">Live access requires venue and user context.</p>
+        <p className="bt-entry__note">Live access requires venue and user context.</p>
       </div>
     </section>
   )

--- a/packages/dashboard/src/features/reports/components/report-blocked-screen.tsx
+++ b/packages/dashboard/src/features/reports/components/report-blocked-screen.tsx
@@ -2,19 +2,19 @@ import { Button } from '../../../components/primitives/button'
 
 export function ReportBlockedScreen() {
   return (
-    <section className="bb-centered-state">
-      <div className="bb-centered-state__icon bb-centered-state__icon--blocked" aria-hidden="true">
-        <span className="bb-centered-state__icon-core" />
-        <span className="bb-centered-state__icon-dot" />
-        <span className="bb-centered-state__icon-slash" />
+    <section className="bt-centered-state">
+      <div className="bt-centered-state__icon bt-centered-state__icon--blocked" aria-hidden="true">
+        <span className="bt-centered-state__icon-core" />
+        <span className="bt-centered-state__icon-dot" />
+        <span className="bt-centered-state__icon-slash" />
       </div>
-      <h1 className="bb-centered-state__title">Access Unavailable</h1>
-      <p className="bb-centered-state__body">
+      <h1 className="bt-centered-state__title">Access Unavailable</h1>
+      <p className="bt-centered-state__body">
         Live report access requires venue and user context. Review submission requires user
         context.
       </p>
-      <div className="bb-centered-state__divider" aria-hidden="true" />
-      <div className="bb-centered-state__actions">
+      <div className="bt-centered-state__divider" aria-hidden="true" />
+      <div className="bt-centered-state__actions">
         <Button disabled fullWidth variant="secondary">
           Submit Review
         </Button>

--- a/packages/dashboard/src/features/reports/components/report-bottle-match-field.tsx
+++ b/packages/dashboard/src/features/reports/components/report-bottle-match-field.tsx
@@ -33,15 +33,15 @@ export function ReportBottleMatchField({
     Boolean(selectedBottleId) && search.results.length === 0 && search.query.trim().length > 0
 
   return (
-    <div className="bb-bottle-match">
-      <label className="bb-field" htmlFor={inputId}>
-        <span className="bb-field__label">{label}</span>
-        <div className="bb-search-field">
-          <span aria-hidden="true" className="bb-search-field__icon">
+    <div className="bt-bottle-match">
+      <label className="bt-field" htmlFor={inputId}>
+        <span className="bt-field__label">{label}</span>
+        <div className="bt-search-field">
+          <span aria-hidden="true" className="bt-search-field__icon">
             ⌕
           </span>
           <input
-            className="bb-input bb-input--search"
+            className="bt-input bt-input--search"
             id={inputId}
             onChange={(event) => {
               const query = event.currentTarget.value
@@ -55,22 +55,22 @@ export function ReportBottleMatchField({
       </label>
 
       {search.results.length > 0 ? (
-        <div aria-label={`${label} results`} className="bb-bottle-match__results">
+        <div aria-label={`${label} results`} className="bt-bottle-match__results">
           {search.results.map((result) => {
             const isSelected = result.id === selectedBottleId
 
             return (
               <button
-                className={`bb-bottle-match__option${isSelected ? ' is-selected' : ''}`}
+                className={`bt-bottle-match__option${isSelected ? ' is-selected' : ''}`}
                 key={result.id}
                 onClick={() => onSelectResult(result)}
                 type="button"
               >
-                <span className="bb-bottle-match__copy">
-                  <span className="bb-bottle-match__name">{result.name}</span>
-                  <span className="bb-bottle-match__meta">{buildBottleSearchMeta(result)}</span>
+                <span className="bt-bottle-match__copy">
+                  <span className="bt-bottle-match__name">{result.name}</span>
+                  <span className="bt-bottle-match__meta">{buildBottleSearchMeta(result)}</span>
                 </span>
-                {isSelected ? <span className="bb-bottle-match__tag">Selected</span> : null}
+                {isSelected ? <span className="bt-bottle-match__tag">Selected</span> : null}
               </button>
             )
           })}
@@ -78,11 +78,11 @@ export function ReportBottleMatchField({
       ) : null}
 
       {showCurrentMatchHint ? (
-        <p className="bb-field__hint">Current match: {search.query}.</p>
+        <p className="bt-field__hint">Current match: {search.query}.</p>
       ) : null}
 
       {showManualMatchHint && !showCurrentMatchHint ? (
-        <p className="bb-field__hint">{emptyHint}</p>
+        <p className="bt-field__hint">{emptyHint}</p>
       ) : null}
     </div>
   )

--- a/packages/dashboard/src/features/reports/components/report-comparison-record-card.tsx
+++ b/packages/dashboard/src/features/reports/components/report-comparison-record-card.tsx
@@ -19,26 +19,26 @@ export function ComparisonRecordCard({
 
   return (
     <SurfaceCard
-      className={`bb-comparison-card${variant === 'hero' ? ' bb-comparison-card--hero' : ''}`}
+      className={`bt-comparison-card${variant === 'hero' ? ' bt-comparison-card--hero' : ''}`}
       tone="low"
     >
       {variant === 'hero' ? (
-        <div className="bb-comparison-card__hero-header">
-          <div className="bb-comparison-card__hero-media">
+        <div className="bt-comparison-card__hero-header">
+          <div className="bt-comparison-card__hero-media">
             <RecordMedia record={record} />
           </div>
-          <div className="bb-comparison-card__record-title">
+          <div className="bt-comparison-card__record-title">
             <h2>{record.bottleName}</h2>
             <p>{record.category ?? 'Uncategorized'}</p>
           </div>
         </div>
       ) : (
-        <div className="bb-comparison-card__record-title">
+        <div className="bt-comparison-card__record-title">
           <h2>{record.bottleName}</h2>
           <p>{record.category ?? 'Uncategorized'}</p>
         </div>
       )}
-      <div className="bb-comparison-grid">
+      <div className="bt-comparison-grid">
         <ComparisonPanel
           fields={comparisonFields}
           fillField={fillField}
@@ -70,11 +70,11 @@ function ComparisonPanel({
   const isFinal = panel === 'final'
 
   return (
-    <div className={`bb-comparison-panel${isFinal ? ' bb-comparison-panel--final' : ''}`}>
+    <div className={`bt-comparison-panel${isFinal ? ' bt-comparison-panel--final' : ''}`}>
       <SectionEyebrow>{isFinal ? 'Final Corrected Values' : 'Original Model Output'}</SectionEyebrow>
       {fields.map((field) => (
-        <div className="bb-comparison-field" key={`${panel}-${field.label}`}>
-          <span className="bb-comparison-field__label">{field.label}</span>
+        <div className="bt-comparison-field" key={`${panel}-${field.label}`}>
+          <span className="bt-comparison-field__label">{field.label}</span>
           <span className={buildComparisonValueClass(field, panel)}>{selectComparisonValue(field, panel)}</span>
         </div>
       ))}
@@ -102,15 +102,15 @@ function ComparisonFillField({
       : field.label
 
   return (
-    <div className={`bb-comparison-field bb-comparison-field--fill${variant === 'hero' ? ' is-hero' : ''}`}>
-      <span className="bb-comparison-field__label">{label}</span>
-      <span className={`bb-comparison-field__fill-value${panel === 'final' ? ' is-final' : ''}`}>
+    <div className={`bt-comparison-field bt-comparison-field--fill${variant === 'hero' ? ' is-hero' : ''}`}>
+      <span className="bt-comparison-field__label">{label}</span>
+      <span className={`bt-comparison-field__fill-value${panel === 'final' ? ' is-final' : ''}`}>
         {value}
       </span>
       {fillTenths !== null ? (
-        <div className="bb-comparison-field__fill-track" aria-hidden="true">
+        <div className="bt-comparison-field__fill-track" aria-hidden="true">
           <span
-            className={`bb-comparison-field__fill-bar${panel === 'final' ? ' is-final' : ''}`}
+            className={`bt-comparison-field__fill-bar${panel === 'final' ? ' is-final' : ''}`}
             style={{ width: `${fillTenths * 10}%` }}
           />
         </div>
@@ -121,10 +121,10 @@ function ComparisonFillField({
 
 function buildComparisonValueClass(field: ComparisonField, panel: 'original' | 'final') {
   if (panel === 'final') {
-    return `bb-comparison-field__value${field.changed ? ' is-final' : ''}`
+    return `bt-comparison-field__value${field.changed ? ' is-final' : ''}`
   }
 
-  return `bb-comparison-field__value${field.changed ? ' is-struck' : ''}`
+  return `bt-comparison-field__value${field.changed ? ' is-struck' : ''}`
 }
 
 function selectComparisonValue(field: ComparisonField, panel: 'original' | 'final') {

--- a/packages/dashboard/src/features/reports/components/report-detail-content.tsx
+++ b/packages/dashboard/src/features/reports/components/report-detail-content.tsx
@@ -53,18 +53,18 @@ export function CreatedReportDetail({
   reportId,
 }: CreatedReportDetailProps) {
   return (
-    <div className="bb-report-screen">
+    <div className="bt-report-screen">
       <ReportHeader
         heading={heading}
         mobileSupportingLine={reportId}
         mobileTitle="Report"
         status={detail.status}
       />
-      <SurfaceCard className="bb-report-meta-slab" tone="low">
+      <SurfaceCard className="bt-report-meta-slab" tone="low">
         <MetadataItem label="Started">{formatReportTimestampLong(detail.startedAt)}</MetadataItem>
       </SurfaceCard>
-      <SurfaceCard className="bb-message-panel" tone="low">
-        <p className="bb-message-panel__body">
+      <SurfaceCard className="bt-message-panel" tone="low">
+        <p className="bt-message-panel__body">
           This report has been created. Processing has not started yet.
         </p>
       </SurfaceCard>
@@ -78,19 +78,19 @@ export function ProcessingReportDetail({
   statusMessage = null,
 }: ProcessingReportDetailProps) {
   return (
-    <div className="bb-report-screen">
-      <SurfaceCard className="bb-processing-header" tone="canvas">
-        <div className="bb-processing-header__copy">
-          <div className="bb-processing-header__meta">
+    <div className="bt-report-screen">
+      <SurfaceCard className="bt-processing-header" tone="canvas">
+        <div className="bt-processing-header__copy">
+          <div className="bt-processing-header__meta">
             <SectionEyebrow>Report ID</SectionEyebrow>
-            <span className="bb-processing-header__report-id">{detail.id}</span>
+            <span className="bt-processing-header__report-id">{detail.id}</span>
           </div>
-          <div className="bb-processing-header__details">
+          <div className="bt-processing-header__details">
             <span>Started at {formatReportTimestampLong(detail.startedAt)}</span>
             <span>Operator: {detail.userDisplayName ?? 'Unknown operator'}</span>
           </div>
         </div>
-        <div className="bb-processing-header__status">
+        <div className="bt-processing-header__status">
           <StatusChip status={detail.status} />
         </div>
       </SurfaceCard>
@@ -98,14 +98,14 @@ export function ProcessingReportDetail({
       <ReportProgressPanel label={progress.label} progress={progress.ratio} />
 
       {statusMessage ? (
-        <SurfaceCard className="bb-message-panel" tone="low">
-          <p aria-live="polite" className="bb-message-panel__body">
+        <SurfaceCard className="bt-message-panel" tone="low">
+          <p aria-live="polite" className="bt-message-panel__body">
             {statusMessage}
           </p>
         </SurfaceCard>
       ) : null}
 
-      <section className="bb-record-stack bb-record-stack--processing">
+      <section className="bt-record-stack bt-record-stack--processing">
         {detail.bottleRecords.map((record) => (
           <ProcessingRecord key={record.id} record={record} />
         ))}
@@ -123,9 +123,9 @@ export function ReviewedReportDetail({
   const isComparisonEmphasis = comparisonVariant === 'hero'
 
   return (
-    <div className="bb-report-screen">
+    <div className="bt-report-screen">
       <div
-        className={`bb-reviewed-shell${isComparisonEmphasis ? ' bb-reviewed-shell--comparison' : ' bb-reviewed-shell--summary'}`}
+        className={`bt-reviewed-shell${isComparisonEmphasis ? ' bt-reviewed-shell--comparison' : ' bt-reviewed-shell--summary'}`}
       >
         <ReportHeader
           heading={heading}
@@ -135,7 +135,7 @@ export function ReviewedReportDetail({
           variant={isComparisonEmphasis ? 'inline-chip' : 'stacked'}
         />
         {!isComparisonEmphasis ? (
-          <div className="bb-reviewed-shell__meta">
+          <div className="bt-reviewed-shell__meta">
             <MetadataLine label="Started" value={formatReportTimestampLong(detail.startedAt)} />
             <MetadataLine label="Completed" value={formatReportTimestampLong(detail.completedAt)} />
             <MetadataLine label="Operator" value={detail.userDisplayName ?? 'Unknown operator'} />
@@ -143,7 +143,7 @@ export function ReviewedReportDetail({
         ) : null}
       </div>
 
-      <div className={`bb-reviewed-grid${isComparisonEmphasis ? ' bb-reviewed-grid--comparison' : ''}`}>
+      <div className={`bt-reviewed-grid${isComparisonEmphasis ? ' bt-reviewed-grid--comparison' : ''}`}>
         {detail.bottleRecords.map((record) => (
           <ComparisonRecordCard key={record.id} record={record} variant={comparisonVariant} />
         ))}
@@ -177,7 +177,7 @@ export function ReviewableReportDetail({
     !readinessMessage
 
   return (
-    <div className="bb-report-screen">
+    <div className="bt-report-screen">
       <ReportHeader
         heading={heading}
         mobileSupportingLine={reportId}
@@ -185,21 +185,21 @@ export function ReviewableReportDetail({
         status={detail.status}
       />
 
-      <SurfaceCard className="bb-report-meta-slab" tone="low">
+      <SurfaceCard className="bt-report-meta-slab" tone="low">
         <MetadataItem label="Started">{formatReportTimestampLong(detail.startedAt)}</MetadataItem>
         <MetadataItem label="Completed">{formatReportTimestampLong(detail.completedAt)}</MetadataItem>
         <MetadataItem label="Operator">{detail.userDisplayName ?? 'Unknown operator'}</MetadataItem>
       </SurfaceCard>
 
       {statusMessage ? (
-        <SurfaceCard className="bb-message-panel" tone="low">
-          <p aria-live="polite" className="bb-message-panel__body">
+        <SurfaceCard className="bt-message-panel" tone="low">
+          <p aria-live="polite" className="bt-message-panel__body">
             {statusMessage}
           </p>
         </SurfaceCard>
       ) : null}
 
-      <section className="bb-record-stack">
+      <section className="bt-record-stack">
         {detail.bottleRecords.map((record) => {
           const draft = reviewDraft.find((entry) => entry.id === record.id)
           const search = searchState[record.id] ?? { query: '', results: [] }
@@ -239,18 +239,18 @@ export function ReviewableReportDetail({
       </section>
 
       <div
-        className={`bb-review-action${showCompactReviewAction ? ' bb-review-action--enabled' : ''}`}
+        className={`bt-review-action${showCompactReviewAction ? ' bt-review-action--enabled' : ''}`}
       >
-        <div className="bb-review-action__copy">
+        <div className="bt-review-action__copy">
           <p
-            className="bb-review-action__helper bb-review-action__helper--error"
+            className="bt-review-action__helper bt-review-action__helper--error"
             hidden={!reviewActionErrorMessage}
             role="alert"
           >
             {reviewActionErrorMessage ?? ''}
           </p>
           {readinessMessage ? (
-            <p className="bb-review-action__helper">{readinessMessage}</p>
+            <p className="bt-review-action__helper">{readinessMessage}</p>
           ) : null}
         </div>
         <Button disabled={reviewActionDisabled} onPress={onReviewSubmit} variant="primary">
@@ -259,7 +259,7 @@ export function ReviewableReportDetail({
       </div>
 
       {hasFailedRecords ? (
-        <p className="bb-report-screen__footnote">Failed records remain recoverable review work.</p>
+        <p className="bt-report-screen__footnote">Failed records remain recoverable review work.</p>
       ) : null}
     </div>
   )

--- a/packages/dashboard/src/features/reports/components/report-detail-metadata.tsx
+++ b/packages/dashboard/src/features/reports/components/report-detail-metadata.tsx
@@ -5,17 +5,17 @@ export function MetadataItem({
   label,
 }: PropsWithChildren<{ label: string }>) {
   return (
-    <div className="bb-metadata-item">
-      <span className="bb-field__label">{label}</span>
-      <span className="bb-metadata-item__value">{children}</span>
+    <div className="bt-metadata-item">
+      <span className="bt-field__label">{label}</span>
+      <span className="bt-metadata-item__value">{children}</span>
     </div>
   )
 }
 
 export function MetadataLine({ label, value }: { label: string; value: string }) {
   return (
-    <div className="bb-metadata-line">
-      <span className="bb-field__label">{label}</span>
+    <div className="bt-metadata-line">
+      <span className="bt-field__label">{label}</span>
       <span>{value}</span>
     </div>
   )

--- a/packages/dashboard/src/features/reports/components/report-header.tsx
+++ b/packages/dashboard/src/features/reports/components/report-header.tsx
@@ -19,20 +19,20 @@ export function ReportHeader({
 
   if (variant === 'inline-chip') {
     return (
-      <header className="bb-report-header bb-report-header--inline">
-        <div className="bb-report-header__headline-row">
-          <h1 aria-label={heading} className="bb-page-title bb-page-title--detail">
-            <span aria-hidden="true" className="bb-report-header__heading-desktop">
+      <header className="bt-report-header bt-report-header--inline">
+        <div className="bt-report-header__headline-row">
+          <h1 aria-label={heading} className="bt-page-title bt-page-title--detail">
+            <span aria-hidden="true" className="bt-report-header__heading-desktop">
               {heading}
             </span>
-            <span aria-hidden="true" className="bb-report-header__heading-mobile">
+            <span aria-hidden="true" className="bt-report-header__heading-mobile">
               {mobileHeading}
             </span>
           </h1>
           <StatusChip status={status} />
         </div>
         {mobileSupportingLine ? (
-          <p aria-hidden="true" className="bb-report-header__mobile-support">
+          <p aria-hidden="true" className="bt-report-header__mobile-support">
             {mobileSupportingLine}
           </p>
         ) : null}
@@ -41,20 +41,20 @@ export function ReportHeader({
   }
 
   return (
-    <header className="bb-report-header">
-      <div className="bb-report-header__chips">
+    <header className="bt-report-header">
+      <div className="bt-report-header__chips">
         <StatusChip status={status} />
       </div>
-      <h1 aria-label={heading} className="bb-page-title bb-page-title--detail">
-        <span aria-hidden="true" className="bb-report-header__heading-desktop">
+      <h1 aria-label={heading} className="bt-page-title bt-page-title--detail">
+        <span aria-hidden="true" className="bt-report-header__heading-desktop">
           {heading}
         </span>
-        <span aria-hidden="true" className="bb-report-header__heading-mobile">
+        <span aria-hidden="true" className="bt-report-header__heading-mobile">
           {mobileHeading}
         </span>
       </h1>
       {mobileSupportingLine ? (
-        <p aria-hidden="true" className="bb-report-header__mobile-support">
+        <p aria-hidden="true" className="bt-report-header__mobile-support">
           {mobileSupportingLine}
         </p>
       ) : null}

--- a/packages/dashboard/src/features/reports/components/report-load-error-screen.tsx
+++ b/packages/dashboard/src/features/reports/components/report-load-error-screen.tsx
@@ -6,19 +6,19 @@ export function ReportLoadErrorScreen({
   onRetry?: () => void
 }) {
   return (
-    <section className="bb-centered-state bb-centered-state--not-found">
-      <div className="bb-centered-state__icon bb-centered-state__icon--not-found" aria-hidden="true">
-        <span className="bb-centered-state__file-icon" />
-        <span className="bb-centered-state__file-badge" />
-        <span className="bb-centered-state__file-badge-line bb-centered-state__file-badge-line--one" />
-        <span className="bb-centered-state__file-badge-line bb-centered-state__file-badge-line--two" />
+    <section className="bt-centered-state bt-centered-state--not-found">
+      <div className="bt-centered-state__icon bt-centered-state__icon--not-found" aria-hidden="true">
+        <span className="bt-centered-state__file-icon" />
+        <span className="bt-centered-state__file-badge" />
+        <span className="bt-centered-state__file-badge-line bt-centered-state__file-badge-line--one" />
+        <span className="bt-centered-state__file-badge-line bt-centered-state__file-badge-line--two" />
       </div>
-      <h1 className="bb-centered-state__title">Report Unavailable</h1>
-      <p className="bb-centered-state__body">
+      <h1 className="bt-centered-state__title">Report Unavailable</h1>
+      <p className="bt-centered-state__body">
         This report could not be loaded right now. Return to reports and try again in a
         moment.
       </p>
-      <div className="bb-centered-state__actions">
+      <div className="bt-centered-state__actions">
         {onRetry ? (
           <Button onPress={onRetry} variant="secondary">
             Retry

--- a/packages/dashboard/src/features/reports/components/report-loading-screen.tsx
+++ b/packages/dashboard/src/features/reports/components/report-loading-screen.tsx
@@ -2,10 +2,10 @@ import { SurfaceCard } from '../../../components/primitives/surface-card'
 
 export function ReportLoadingScreen() {
   return (
-    <div className="bb-report-screen">
-      <SurfaceCard className="bb-loading-panel" tone="low">
-        <p className="bb-loading-panel__eyebrow">Report</p>
-        <p className="bb-loading-panel__body">Loading report details.</p>
+    <div className="bt-report-screen">
+      <SurfaceCard className="bt-loading-panel" tone="low">
+        <p className="bt-loading-panel__eyebrow">Report</p>
+        <p className="bt-loading-panel__body">Loading report details.</p>
       </SurfaceCard>
     </div>
   )

--- a/packages/dashboard/src/features/reports/components/report-not-found-screen.tsx
+++ b/packages/dashboard/src/features/reports/components/report-not-found-screen.tsx
@@ -2,18 +2,18 @@ import { Button } from '../../../components/primitives/button'
 
 export function ReportNotFoundScreen() {
   return (
-    <section className="bb-centered-state bb-centered-state--not-found">
-      <div className="bb-centered-state__icon bb-centered-state__icon--not-found" aria-hidden="true">
-        <span className="bb-centered-state__file-icon" />
-        <span className="bb-centered-state__file-badge" />
-        <span className="bb-centered-state__file-badge-line bb-centered-state__file-badge-line--one" />
-        <span className="bb-centered-state__file-badge-line bb-centered-state__file-badge-line--two" />
+    <section className="bt-centered-state bt-centered-state--not-found">
+      <div className="bt-centered-state__icon bt-centered-state__icon--not-found" aria-hidden="true">
+        <span className="bt-centered-state__file-icon" />
+        <span className="bt-centered-state__file-badge" />
+        <span className="bt-centered-state__file-badge-line bt-centered-state__file-badge-line--one" />
+        <span className="bt-centered-state__file-badge-line bt-centered-state__file-badge-line--two" />
       </div>
-      <h1 className="bb-centered-state__title">Report Not Found</h1>
-      <p className="bb-centered-state__body">
+      <h1 className="bt-centered-state__title">Report Not Found</h1>
+      <p className="bt-centered-state__body">
         This report could not be found. Return to reports and choose another report.
       </p>
-      <div className="bb-centered-state__actions">
+      <div className="bt-centered-state__actions">
         <Button to="/reports" variant="ghost">
           Back to Reports
         </Button>

--- a/packages/dashboard/src/features/reports/components/report-processing-record.tsx
+++ b/packages/dashboard/src/features/reports/components/report-processing-record.tsx
@@ -4,23 +4,23 @@ import { SurfaceCard } from '../../../components/primitives/surface-card'
 export function ProcessingRecord({ record }: { record: ReportBottleRecord }) {
   return (
     <SurfaceCard
-      className={`bb-processing-record${record.status === 'pending' ? ' bb-processing-record--pending' : ''}`}
+      className={`bt-processing-record${record.status === 'pending' ? ' bt-processing-record--pending' : ''}`}
       tone="base"
     >
-      <div className="bb-processing-record__media">
+      <div className="bt-processing-record__media">
         {record.imageUrl ? (
           <img alt={record.bottleName} height={96} src={record.imageUrl} width={72} />
         ) : (
-          <div className="bb-processing-record__placeholder">◻</div>
+          <div className="bt-processing-record__placeholder">◻</div>
         )}
       </div>
-      <div className="bb-processing-record__summary">
+      <div className="bt-processing-record__summary">
         {record.status === 'pending' ? (
-          <p className="bb-processing-record__pending">Processing…</p>
+          <p className="bt-processing-record__pending">Processing…</p>
         ) : (
           <>
-            <h3 className="bb-processing-record__title">{record.bottleName}</h3>
-            <p className="bb-processing-record__meta">{record.category ?? 'Uncategorized'}</p>
+            <h3 className="bt-processing-record__title">{record.bottleName}</h3>
+            <p className="bt-processing-record__meta">{record.category ?? 'Uncategorized'}</p>
           </>
         )}
       </div>

--- a/packages/dashboard/src/features/reports/components/report-progress-panel.tsx
+++ b/packages/dashboard/src/features/reports/components/report-progress-panel.tsx
@@ -10,20 +10,20 @@ export function ReportProgressPanel({
   const progressPercent = Math.max(0, Math.min(100, Math.round(progress * 100)))
 
   return (
-    <section className="bb-progress-panel">
-      <div className="bb-progress-panel__meta">
-        <span className="bb-field__label">Progress</span>
-        <span className="bb-progress-panel__label">{label}</span>
+    <section className="bt-progress-panel">
+      <div className="bt-progress-panel__meta">
+        <span className="bt-field__label">Progress</span>
+        <span className="bt-progress-panel__label">{label}</span>
       </div>
       <div
         aria-label={label}
         aria-valuemax={100}
         aria-valuemin={0}
         aria-valuenow={progressPercent}
-        className="bb-progress-bar"
+        className="bt-progress-bar"
         role="progressbar"
       >
-        <span className="bb-progress-bar__fill" style={{ width: `${progressPercent}%` }} />
+        <span className="bt-progress-bar__fill" style={{ width: `${progressPercent}%` }} />
       </div>
     </section>
   )

--- a/packages/dashboard/src/features/reports/components/report-record-media.tsx
+++ b/packages/dashboard/src/features/reports/components/report-record-media.tsx
@@ -3,7 +3,7 @@ import type { ReportBottleRecord } from '@bartools/types'
 export function RecordMedia({ record }: { record: ReportBottleRecord }) {
   if (!record.imageUrl) {
     return (
-      <div className="bb-record-media bb-record-media--missing">
+      <div className="bt-record-media bt-record-media--missing">
         <span aria-hidden="true">⌁</span>
         <p>Image unavailable</p>
       </div>
@@ -11,7 +11,7 @@ export function RecordMedia({ record }: { record: ReportBottleRecord }) {
   }
 
   return (
-    <div className="bb-record-media">
+    <div className="bt-record-media">
       <img alt={record.bottleName} height={96} src={record.imageUrl} width={72} />
     </div>
   )

--- a/packages/dashboard/src/features/reports/components/report-review-record-card.tsx
+++ b/packages/dashboard/src/features/reports/components/report-review-record-card.tsx
@@ -29,20 +29,20 @@ export function ReviewRecordCard({
   const inputId = useId()
 
   return (
-    <SurfaceCard className="bb-record-card" tone="low">
-      <div className="bb-record-card__media-slab">
+    <SurfaceCard className="bt-record-card" tone="low">
+      <div className="bt-record-card__media-slab">
         <RecordMedia record={record} />
-        <div className="bb-record-card__summary">
+        <div className="bt-record-card__summary">
           <SectionEyebrow>{record.category ?? 'Record'}</SectionEyebrow>
-          <h3 className="bb-record-card__title">{record.bottleName}</h3>
-          <p className="bb-record-card__meta">
+          <h3 className="bt-record-card__title">{record.bottleName}</h3>
+          <p className="bt-record-card__meta">
             {record.upc ? `UPC ${record.upc}` : 'UPC unavailable'}
             {record.volumeMl ? ` • ${record.volumeMl}ml` : ''}
           </p>
         </div>
       </div>
-      <div className="bb-record-card__controls">
-        <div className="bb-field-group">
+      <div className="bt-record-card__controls">
+        <div className="bt-field-group">
           <ReportBottleMatchField
             inputId={inputId}
             onQueryChange={(query) => onSearchQueryChange(record.id, query)}
@@ -78,21 +78,21 @@ export function FailedRecordCard({
   const inputId = useId()
 
   return (
-    <SurfaceCard className="bb-record-card bb-record-card--failed" tone="low">
-      <span className="bb-record-card__error-strip" aria-hidden="true" />
-      <div className="bb-record-card__failed-media">
+    <SurfaceCard className="bt-record-card bt-record-card--failed" tone="low">
+      <span className="bt-record-card__error-strip" aria-hidden="true" />
+      <div className="bt-record-card__failed-media">
         <RecordMedia record={record} />
       </div>
-      <div className="bb-record-card__failed-content">
-        <div className="bb-record-card__failed-header">
-          <h3 className="bb-record-card__title">{record.bottleName}</h3>
+      <div className="bt-record-card__failed-content">
+        <div className="bt-record-card__failed-header">
+          <h3 className="bt-record-card__title">{record.bottleName}</h3>
           <StatusChip status="failed" />
         </div>
-        <SurfaceCard className="bb-error-panel" tone="canvas">
+        <SurfaceCard className="bt-error-panel" tone="canvas">
           <SectionEyebrow>Error Code: {record.errorCode ?? 'unknown'}</SectionEyebrow>
           <p>{record.errorMessage ?? 'This record needs manual review.'}</p>
         </SurfaceCard>
-        <div className="bb-record-card__failed-controls">
+        <div className="bt-record-card__failed-controls">
           <ReportBottleMatchField
             inputId={inputId}
             onQueryChange={(query) => onSearchQueryChange(record.id, query)}
@@ -123,19 +123,19 @@ function TenthsRailField({
   onSelect: (value: number) => void
 }) {
   return (
-    <div className="bb-field-group">
-      <div className="bb-fill-rail__header">
-        <span className="bb-field__label">Observed Fill Level</span>
-        <span className="bb-fill-rail__value">{fillTenths}</span>
+    <div className="bt-field-group">
+      <div className="bt-fill-rail__header">
+        <span className="bt-field__label">Observed Fill Level</span>
+        <span className="bt-fill-rail__value">{fillTenths}</span>
       </div>
-      <div className="bb-fill-rail">
-        <div className="bb-fill-rail__track" aria-hidden="true">
-          <span className="bb-fill-rail__fill" style={{ width: `${fillTenths * 10}%` }} />
+      <div className="bt-fill-rail">
+        <div className="bt-fill-rail__track" aria-hidden="true">
+          <span className="bt-fill-rail__fill" style={{ width: `${fillTenths * 10}%` }} />
         </div>
-        <div className="bb-fill-rail__options">
+        <div className="bt-fill-rail__options">
           {Array.from({ length: 11 }, (_, value) => (
             <button
-              className={`bb-fill-rail__option${value === fillTenths ? ' is-active' : ''}`}
+              className={`bt-fill-rail__option${value === fillTenths ? ' is-active' : ''}`}
               key={value}
               onClick={() => onSelect(value)}
               type="button"
@@ -157,12 +157,12 @@ function TenthsGridField({
   onSelect: (value: number) => void
 }) {
   return (
-    <div className="bb-field">
-      <span className="bb-field__label">Fill Level (Tenths)</span>
-      <div className="bb-fill-grid">
+    <div className="bt-field">
+      <span className="bt-field__label">Fill Level (Tenths)</span>
+      <div className="bt-fill-grid">
         {Array.from({ length: 11 }, (_, value) => (
           <button
-            className={`bb-fill-grid__option${value === fillTenths ? ' is-active' : ''}`}
+            className={`bt-fill-grid__option${value === fillTenths ? ' is-active' : ''}`}
             key={value}
             onClick={() => onSelect(value)}
             type="button"

--- a/packages/dashboard/src/features/reports/components/reports-empty-screen.tsx
+++ b/packages/dashboard/src/features/reports/components/reports-empty-screen.tsx
@@ -3,16 +3,16 @@ import { SurfaceCard } from '../../../components/primitives/surface-card'
 
 export function ReportsEmptyScreen() {
   return (
-    <div className="bb-reports-empty">
-      <SurfaceCard className="bb-empty-state" tone="low">
-        <div className="bb-empty-state__icon" aria-hidden="true">
+    <div className="bt-reports-empty">
+      <SurfaceCard className="bt-empty-state" tone="low">
+        <div className="bt-empty-state__icon" aria-hidden="true">
           ⧉
         </div>
-        <h2 className="bb-empty-state__title">Reports</h2>
-        <p className="bb-empty-state__body">
+        <h2 className="bt-empty-state__title">Reports</h2>
+        <p className="bt-empty-state__body">
           No reports found. Recent reports will appear here once they are available.
         </p>
-        <div className="bb-loading-panel__actions">
+        <div className="bt-loading-panel__actions">
           <Button to="/reports/backstock/new" variant="secondary">
             New Backstock Report
           </Button>

--- a/packages/dashboard/src/features/reports/components/reports-list-header.tsx
+++ b/packages/dashboard/src/features/reports/components/reports-list-header.tsx
@@ -2,10 +2,10 @@ import { Button } from '../../../components/primitives/button'
 
 export function ReportsListHeader() {
   return (
-    <section className="bb-reports-header">
-      <div className="bb-reports-header__copy">
-        <h1 className="bb-page-title">Reports</h1>
-        <p className="bb-reports-header__support">
+    <section className="bt-reports-header">
+      <div className="bt-reports-header__copy">
+        <h1 className="bt-page-title">Reports</h1>
+        <p className="bt-reports-header__support">
           Review recent reports and open one to inspect records.
         </p>
       </div>

--- a/packages/dashboard/src/features/reports/components/reports-list-row.tsx
+++ b/packages/dashboard/src/features/reports/components/reports-list-row.tsx
@@ -8,32 +8,32 @@ type ReportsListRowProps = {
 
 export function ReportsListRow({ report }: ReportsListRowProps) {
   return (
-    <Link className="bb-reports-row" to={`/reports/${report.id}`}>
-      <span className="bb-reports-row__hoverrail" aria-hidden="true" />
-      <div className="bb-reports-row__id">
-        <span className="bb-reports-row__field-label">Report</span>
-        <span className="bb-reports-row__field-value">{report.id}</span>
-        <span className="bb-reports-row__field-detail">{report.location}</span>
+    <Link className="bt-reports-row" to={`/reports/${report.id}`}>
+      <span className="bt-reports-row__hoverrail" aria-hidden="true" />
+      <div className="bt-reports-row__id">
+        <span className="bt-reports-row__field-label">Report</span>
+        <span className="bt-reports-row__field-value">{report.id}</span>
+        <span className="bt-reports-row__field-detail">{report.location}</span>
       </div>
-      <div className="bb-reports-row__status">
+      <div className="bt-reports-row__status">
         <StatusChip status={report.status} />
       </div>
-      <div className="bb-reports-row__operator">
-        <span className="bb-reports-row__field-label">Operator</span>
-        <span className="bb-reports-row__field-value">{report.operator}</span>
+      <div className="bt-reports-row__operator">
+        <span className="bt-reports-row__field-label">Operator</span>
+        <span className="bt-reports-row__field-value">{report.operator}</span>
       </div>
-      <div className="bb-reports-row__started">
-        <span className="bb-reports-row__field-label">Started</span>
-        <span className="bb-reports-row__field-value">{report.startedAt}</span>
+      <div className="bt-reports-row__started">
+        <span className="bt-reports-row__field-label">Started</span>
+        <span className="bt-reports-row__field-value">{report.startedAt}</span>
       </div>
-      <div className="bb-reports-row__completed">
-        <span className="bb-reports-row__field-label">Completed</span>
-        <span className="bb-reports-row__field-value">{report.completedAt}</span>
+      <div className="bt-reports-row__completed">
+        <span className="bt-reports-row__field-label">Completed</span>
+        <span className="bt-reports-row__field-value">{report.completedAt}</span>
       </div>
-      <div className="bb-reports-row__count">
-        <span className="bb-reports-row__field-label">Progress</span>
-        <span className="bb-reports-row__count-value">{report.progressLabel}</span>
-        <span className="bb-reports-row__count-detail">{report.bottleCountLabel}</span>
+      <div className="bt-reports-row__count">
+        <span className="bt-reports-row__field-label">Progress</span>
+        <span className="bt-reports-row__count-value">{report.progressLabel}</span>
+        <span className="bt-reports-row__count-detail">{report.bottleCountLabel}</span>
       </div>
     </Link>
   )

--- a/packages/dashboard/src/features/reports/components/reports-list-screen.tsx
+++ b/packages/dashboard/src/features/reports/components/reports-list-screen.tsx
@@ -20,15 +20,15 @@ export function ReportsListScreen({
   const rows = reports ? buildReportListRows(reports) : []
 
   return (
-    <div className="bb-reports-screen">
+    <div className="bt-reports-screen">
       <ReportsListHeader />
 
       {errorMessage ? (
-        <SurfaceCard className="bb-loading-panel" tone="low">
-          <p className="bb-loading-panel__eyebrow">Reports Unavailable</p>
-          <p className="bb-loading-panel__body">{errorMessage}</p>
+        <SurfaceCard className="bt-loading-panel" tone="low">
+          <p className="bt-loading-panel__eyebrow">Reports Unavailable</p>
+          <p className="bt-loading-panel__body">{errorMessage}</p>
           {onRetry ? (
-            <div className="bb-loading-panel__actions">
+            <div className="bt-loading-panel__actions">
               <Button onPress={onRetry} variant="secondary">
                 Retry
               </Button>
@@ -36,15 +36,15 @@ export function ReportsListScreen({
           ) : null}
         </SurfaceCard>
       ) : reports === null ? (
-        <SurfaceCard className="bb-loading-panel" tone="low">
-          <p className="bb-loading-panel__eyebrow">Reports</p>
-          <p className="bb-loading-panel__body">Loading recent reports.</p>
+        <SurfaceCard className="bt-loading-panel" tone="low">
+          <p className="bt-loading-panel__eyebrow">Reports</p>
+          <p className="bt-loading-panel__body">Loading recent reports.</p>
         </SurfaceCard>
       ) : rows.length === 0 ? (
         <ReportsEmptyScreen />
       ) : (
-        <section className="bb-reports-list">
-          <div className="bb-reports-columns" aria-hidden="true">
+        <section className="bt-reports-list">
+          <div className="bt-reports-columns" aria-hidden="true">
             <div>Report</div>
             <div>Status</div>
             <div>Operator</div>
@@ -52,7 +52,7 @@ export function ReportsListScreen({
             <div>Completed</div>
             <div>Progress</div>
           </div>
-          <div className="bb-reports-rows">
+          <div className="bt-reports-rows">
             {rows.map((report) => (
               <ReportsListRow key={report.id} report={report} />
             ))}

--- a/packages/dashboard/src/features/reports/routes/reports-route.test.tsx
+++ b/packages/dashboard/src/features/reports/routes/reports-route.test.tsx
@@ -58,7 +58,7 @@ describe('Reports workbench routes: baseline states', () => {
 
     const failedRecordCard = (
       await screen.findByText(/catalog_no_match/i)
-    ).closest('.bb-record-card')
+    ).closest('.bt-record-card')
 
     expect(failedRecordCard).toBeTruthy()
     await user.type(

--- a/packages/dashboard/src/features/reports/styles/report-detail.css
+++ b/packages/dashboard/src/features/reports/styles/report-detail.css
@@ -1,51 +1,51 @@
-.bb-report-header,
-.bb-reviewed-shell {
+.bt-report-header,
+.bt-reviewed-shell {
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
 }
 
-.bb-report-header {
+.bt-report-header {
   max-width: 960px;
 }
 
-.bb-report-header__chips {
+.bt-report-header__chips {
   display: flex;
   gap: var(--space-lg);
 }
 
-.bb-report-meta-slab,
-.bb-processing-header {
+.bt-report-meta-slab,
+.bt-processing-header {
   display: grid;
   gap: var(--space-lg);
   padding: var(--space-2xl);
 }
 
-.bb-report-meta-slab {
+.bt-report-meta-slab {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.bb-processing-header {
+.bt-processing-header {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: end;
 }
 
-.bb-processing-header__copy {
+.bt-processing-header__copy {
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
 }
 
-.bb-metadata-item,
-.bb-processing-header__meta,
-.bb-processing-header__details,
-.bb-processing-header__status {
+.bt-metadata-item,
+.bt-processing-header__meta,
+.bt-processing-header__details,
+.bt-processing-header__status {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
 }
 
-.bb-processing-header__details {
+.bt-processing-header__details {
   flex-direction: row;
   flex-wrap: wrap;
   gap: var(--space-lg);
@@ -53,20 +53,20 @@
   font-size: var(--type-body-compact-size);
 }
 
-.bb-processing-header__status {
+.bt-processing-header__status {
   align-items: end;
 }
 
-.bb-metadata-item__value,
-.bb-processing-header__report-id,
-.bb-review-action__title {
+.bt-metadata-item__value,
+.bt-processing-header__report-id,
+.bt-review-action__title {
   font-size: var(--type-body-size);
   font-weight: 600;
   color: var(--color-text-primary);
 }
 
-.bb-field__label,
-.bb-section-eyebrow {
+.bt-field__label,
+.bt-section-eyebrow {
   font-family: var(--font-label);
   font-size: var(--type-label-size);
   letter-spacing: var(--tracking-label);
@@ -74,23 +74,23 @@
   color: var(--color-text-muted);
 }
 
-.bb-section-eyebrow {
+.bt-section-eyebrow {
   margin: 0;
 }
 
-.bb-progress-panel {
+.bt-progress-panel {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
 }
 
-.bb-progress-panel__meta {
+.bt-progress-panel__meta {
   display: flex;
   justify-content: space-between;
   gap: var(--space-lg);
 }
 
-.bb-progress-panel__label {
+.bt-progress-panel__label {
   font-family: var(--font-label);
   font-size: var(--type-label-size);
   font-variant-numeric: tabular-nums;
@@ -99,50 +99,50 @@
   color: var(--color-accent);
 }
 
-.bb-progress-bar {
+.bt-progress-bar {
   position: relative;
   height: 2px;
   background: var(--color-surface-high);
   overflow: hidden;
 }
 
-.bb-progress-bar__fill {
+.bt-progress-bar__fill {
   position: absolute;
   inset: 0 auto 0 0;
   background: var(--color-accent);
 }
 
-.bb-record-stack,
-.bb-reviewed-grid {
+.bt-record-stack,
+.bt-reviewed-grid {
   display: flex;
   flex-direction: column;
   gap: var(--space-3xl);
 }
 
-.bb-reviewed-grid {
+.bt-reviewed-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.bb-processing-record {
+.bt-processing-record {
   display: flex;
   align-items: center;
   gap: var(--space-lg);
   padding: var(--space-lg);
 }
 
-.bb-processing-record--pending {
+.bt-processing-record--pending {
   opacity: 0.72;
 }
 
-.bb-processing-record__pending {
+.bt-processing-record__pending {
   margin: 0;
   color: var(--color-text-muted-soft);
   font-size: var(--type-body-size);
 }
 
-.bb-processing-record__media,
-.bb-record-media {
+.bt-processing-record__media,
+.bt-record-media {
   width: 72px;
   height: 96px;
   overflow: hidden;
@@ -151,8 +151,8 @@
   border: 1px solid var(--color-border-subtle);
 }
 
-.bb-record-media--missing,
-.bb-processing-record__placeholder {
+.bt-record-media--missing,
+.bt-processing-record__placeholder {
   display: flex;
   width: 72px;
   height: 96px;
@@ -163,7 +163,7 @@
   color: var(--color-text-muted);
 }
 
-.bb-record-media--missing {
+.bt-record-media--missing {
   width: 100%;
   flex-direction: column;
   gap: var(--space-sm);
@@ -173,18 +173,18 @@
   text-transform: uppercase;
 }
 
-.bb-processing-record__media img,
-.bb-record-media img {
+.bt-processing-record__media img,
+.bt-record-media img {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.bb-processing-record__title,
-.bb-record-card__title,
-.bb-centered-state__title,
-.bb-comparison-card__record-title h2,
-.bb-resolved-card__header h2 {
+.bt-processing-record__title,
+.bt-record-card__title,
+.bt-centered-state__title,
+.bt-comparison-card__record-title h2,
+.bt-resolved-card__header h2 {
   margin: 0;
   font-family: var(--font-display);
   font-size: var(--type-section-title-compact-size);
@@ -193,26 +193,26 @@
   color: var(--color-text-primary);
 }
 
-.bb-processing-record__meta,
-.bb-record-card__meta,
-.bb-reviewed-shell__meta,
-.bb-resolved-card__meta,
-.bb-centered-state__body,
-.bb-review-action__body,
-.bb-review-action__note,
-.bb-message-panel__body,
-.bb-report-screen__footnote {
+.bt-processing-record__meta,
+.bt-record-card__meta,
+.bt-reviewed-shell__meta,
+.bt-resolved-card__meta,
+.bt-centered-state__body,
+.bt-review-action__body,
+.bt-review-action__note,
+.bt-message-panel__body,
+.bt-report-screen__footnote {
   font-size: var(--type-body-compact-size);
   color: var(--color-text-muted);
 }
 
-.bb-record-card {
+.bt-record-card {
   display: grid;
   grid-template-columns: minmax(280px, 320px) minmax(0, 1fr);
   overflow: hidden;
 }
 
-.bb-record-card__media-slab {
+.bt-record-card__media-slab {
   display: flex;
   gap: var(--space-2xl);
   align-items: center;
@@ -220,60 +220,60 @@
   background: var(--color-bg-canvas);
 }
 
-.bb-record-card__summary {
+.bt-record-card__summary {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
 }
 
-.bb-record-card__controls,
-.bb-record-card__failed-content {
+.bt-record-card__controls,
+.bt-record-card__failed-content {
   display: flex;
   flex-direction: column;
   gap: var(--space-2xl);
   padding: var(--space-2xl);
 }
 
-.bb-model-output,
-.bb-error-panel {
+.bt-model-output,
+.bt-error-panel {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
   padding: var(--space-lg);
 }
 
-.bb-message-panel {
+.bt-message-panel {
   max-width: 960px;
   padding: var(--space-2xl);
 }
 
-.bb-model-output p,
-.bb-error-panel p {
+.bt-model-output p,
+.bt-error-panel p {
   margin: 0;
   color: var(--color-text-secondary);
   line-height: 1.6;
 }
 
-.bb-field-group,
-.bb-field {
+.bt-field-group,
+.bt-field {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
 }
 
-.bb-field__hint {
+.bt-field__hint {
   margin: 0;
   color: var(--color-text-muted);
   font-size: var(--type-body-compact-size);
 }
 
-.bb-inline-search {
+.bt-inline-search {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: var(--space-sm);
 }
 
-.bb-search-field {
+.bt-search-field {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
@@ -284,18 +284,18 @@
   padding: 0 14px;
 }
 
-.bb-search-field:focus-within {
+.bt-search-field:focus-within {
   border-color: var(--color-accent-soft);
   box-shadow: 0 0 0 2px var(--color-accent-wash-soft);
 }
 
-.bb-search-field__icon {
+.bt-search-field__icon {
   color: var(--color-text-muted);
   font-size: 15px;
 }
 
-.bb-input,
-.bb-select {
+.bt-input,
+.bt-select {
   width: 100%;
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-sm);
@@ -304,25 +304,25 @@
   padding: 12px 14px;
 }
 
-.bb-input--search {
+.bt-input--search {
   border: 0;
   background: transparent;
   padding: 12px 0;
 }
 
-.bb-bottle-match {
+.bt-bottle-match {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
 }
 
-.bb-bottle-match__results {
+.bt-bottle-match__results {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
 }
 
-.bb-bottle-match__option {
+.bt-bottle-match__option {
   display: flex;
   align-items: start;
   justify-content: space-between;
@@ -340,41 +340,41 @@
     color 160ms ease;
 }
 
-.bb-bottle-match__option:hover {
+.bt-bottle-match__option:hover {
   border-color: var(--color-border-strong);
   background: var(--color-surface-low);
 }
 
-.bb-bottle-match__option:focus-visible,
-.bb-fill-rail__option:focus-visible,
-.bb-fill-grid__option:focus-visible {
+.bt-bottle-match__option:focus-visible,
+.bt-fill-rail__option:focus-visible,
+.bt-fill-grid__option:focus-visible {
   outline: 2px solid var(--color-accent-soft);
   outline-offset: 2px;
 }
 
-.bb-bottle-match__option.is-selected {
+.bt-bottle-match__option.is-selected {
   border-color: var(--color-accent);
   background: var(--color-surface-low);
 }
 
-.bb-bottle-match__copy {
+.bt-bottle-match__copy {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
 }
 
-.bb-bottle-match__name {
+.bt-bottle-match__name {
   font-size: var(--type-body-size);
   font-weight: 600;
 }
 
-.bb-bottle-match__meta {
+.bt-bottle-match__meta {
   color: var(--color-text-muted);
   font-size: var(--type-body-compact-size);
   line-height: 1.4;
 }
 
-.bb-bottle-match__tag {
+.bt-bottle-match__tag {
   border-radius: var(--radius-sm);
   background: var(--color-accent-wash-soft);
   color: var(--color-accent-soft);
@@ -385,51 +385,51 @@
   text-transform: uppercase;
 }
 
-.bb-fill-rail {
+.bt-fill-rail {
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
 }
 
-.bb-fill-rail__header {
+.bt-fill-rail__header {
   display: flex;
   align-items: end;
   justify-content: space-between;
   gap: var(--space-md);
 }
 
-.bb-fill-rail__value {
+.bt-fill-rail__value {
   font-family: var(--font-display);
   font-size: 28px;
   font-variant-numeric: tabular-nums;
   color: var(--color-accent);
 }
 
-.bb-fill-rail__track {
+.bt-fill-rail__track {
   position: relative;
   height: 2px;
   background: var(--color-border-strong);
 }
 
-.bb-fill-rail__fill {
+.bt-fill-rail__fill {
   position: absolute;
   inset: 0 auto 0 0;
   background: var(--color-accent);
 }
 
-.bb-fill-rail__options,
-.bb-fill-grid {
+.bt-fill-rail__options,
+.bt-fill-grid {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-sm);
 }
 
-.bb-fill-rail__options {
+.bt-fill-rail__options {
   justify-content: space-between;
 }
 
-.bb-fill-rail__option,
-.bb-fill-grid__option {
+.bt-fill-rail__option,
+.bt-fill-grid__option {
   min-width: 36px;
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-sm);
@@ -440,53 +440,53 @@
   transition: border-color 160ms ease, color 160ms ease, background-color 160ms ease;
 }
 
-.bb-fill-grid__option {
+.bt-fill-grid__option {
   width: 40px;
   height: 40px;
   padding: 0;
 }
 
-.bb-fill-rail__option.is-active,
-.bb-fill-grid__option.is-active {
+.bt-fill-rail__option.is-active,
+.bt-fill-grid__option.is-active {
   border-color: var(--color-accent);
   background: var(--color-accent-wash);
   color: var(--color-accent-soft);
 }
 
-.bb-record-card--failed {
+.bt-record-card--failed {
   position: relative;
   grid-template-columns: minmax(216px, 0.82fr) minmax(0, 1.92fr);
 }
 
-.bb-record-card__error-strip {
+.bt-record-card__error-strip {
   position: absolute;
   inset: 0 auto 0 0;
   width: 4px;
   background: var(--color-error);
 }
 
-.bb-record-card__failed-media {
+.bt-record-card__failed-media {
   min-height: 236px;
   background: var(--color-bg-canvas);
   padding: var(--space-xl);
 }
 
-.bb-record-card__failed-media .bb-record-media,
-.bb-record-card__failed-media .bb-record-media--missing {
+.bt-record-card__failed-media .bt-record-media,
+.bt-record-card__failed-media .bt-record-media--missing {
   width: 100%;
   height: 100%;
   min-height: 188px;
 }
 
-.bb-record-card__failed-header,
-.bb-resolved-card__header {
+.bt-record-card__failed-header,
+.bt-resolved-card__header {
   display: flex;
   align-items: start;
   justify-content: space-between;
   gap: var(--space-lg);
 }
 
-.bb-record-card__failed-controls {
+.bt-record-card__failed-controls {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-2xl);

--- a/packages/dashboard/src/features/reports/styles/report-review-action.css
+++ b/packages/dashboard/src/features/reports/styles/report-review-action.css
@@ -1,4 +1,4 @@
-.bb-review-action {
+.bt-review-action {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -7,23 +7,23 @@
   padding-top: var(--space-xl);
 }
 
-.bb-review-action__copy {
+.bt-review-action__copy {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
 }
 
-.bb-review-action__helper {
+.bt-review-action__helper {
   margin: 0;
   font-size: var(--type-body-compact-size);
   line-height: 1.5;
   color: var(--color-text-muted);
 }
 
-.bb-review-action__helper--error {
+.bt-review-action__helper--error {
   color: var(--color-error);
 }
 
-.bb-review-action--enabled {
+.bt-review-action--enabled {
   justify-content: flex-end;
 }

--- a/packages/dashboard/src/features/reports/styles/report-states-responsive.css
+++ b/packages/dashboard/src/features/reports/styles/report-states-responsive.css
@@ -1,64 +1,64 @@
-.bb-review-action__helper,
-.bb-empty-state__title {
+.bt-review-action__helper,
+.bt-empty-state__title {
   margin: 0;
 }
 
-.bb-review-action__helper,
-.bb-report-screen__footnote {
+.bt-review-action__helper,
+.bt-report-screen__footnote {
   line-height: 1.6;
 }
 
-.bb-review-action__helper {
+.bt-review-action__helper {
   max-width: 620px;
   color: var(--color-text-muted);
 }
 
-.bb-report-header--inline .bb-report-header__headline-row {
+.bt-report-header--inline .bt-report-header__headline-row {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: var(--space-lg);
 }
 
-.bb-reviewed-shell {
+.bt-reviewed-shell {
   border-bottom: 1px solid var(--color-border-subtle);
   padding-bottom: var(--space-3xl);
 }
 
-.bb-reviewed-shell--summary {
+.bt-reviewed-shell--summary {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: end;
   gap: var(--space-3xl);
 }
 
-.bb-reviewed-shell--comparison {
+.bt-reviewed-shell--comparison {
   border-bottom: 0;
   padding-bottom: var(--space-xl);
 }
 
-.bb-reviewed-shell__meta {
+.bt-reviewed-shell__meta {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: var(--space-lg);
 }
 
-.bb-reviewed-shell--summary .bb-reviewed-shell__meta {
+.bt-reviewed-shell--summary .bt-reviewed-shell__meta {
   min-width: 280px;
   flex-direction: column;
   align-items: flex-end;
   gap: var(--space-sm);
 }
 
-.bb-metadata-line {
+.bt-metadata-line {
   display: flex;
   gap: var(--space-sm);
   align-items: center;
 }
 
-.bb-comparison-card,
-.bb-resolved-card {
+.bt-comparison-card,
+.bt-resolved-card {
   display: flex;
   flex-direction: column;
   gap: var(--space-2xl);
@@ -66,27 +66,27 @@
   box-shadow: var(--shadow-ambient);
 }
 
-.bb-reviewed-grid--comparison {
+.bt-reviewed-grid--comparison {
   max-width: 860px;
 }
 
-.bb-resolved-card__media {
+.bt-resolved-card__media {
   width: 120px;
 }
 
-.bb-comparison-card__record-title {
+.bt-comparison-card__record-title {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
 }
 
-.bb-comparison-card--hero {
+.bt-comparison-card--hero {
   gap: 0;
   padding: 0;
   overflow: hidden;
 }
 
-.bb-comparison-card__hero-header {
+.bt-comparison-card__hero-header {
   display: flex;
   align-items: center;
   gap: var(--space-lg);
@@ -94,18 +94,18 @@
   border-bottom: 1px solid var(--color-border-subtle);
 }
 
-.bb-comparison-card__hero-media {
+.bt-comparison-card__hero-media {
   flex: 0 0 auto;
 }
 
-.bb-comparison-card__hero-media .bb-record-media,
-.bb-comparison-card__hero-media .bb-record-media--missing {
+.bt-comparison-card__hero-media .bt-record-media,
+.bt-comparison-card__hero-media .bt-record-media--missing {
   width: 52px;
   height: 68px;
 }
 
-.bb-processing-record__media img,
-.bb-record-media img {
+.bt-processing-record__media img,
+.bt-record-media img {
   display: block;
   width: 100%;
   height: 100%;
@@ -115,7 +115,7 @@
   opacity: 0.82;
 }
 
-.bb-comparison-card__record-title p {
+.bt-comparison-card__record-title p {
   margin: 0;
   font-family: var(--font-label);
   font-size: var(--type-label-size);
@@ -124,14 +124,14 @@
   text-transform: uppercase;
 }
 
-.bb-comparison-grid {
+.bt-comparison-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1px;
   background: var(--color-border-subtle);
 }
 
-.bb-comparison-panel {
+.bt-comparison-panel {
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
@@ -139,17 +139,17 @@
   background: var(--color-bg-canvas);
 }
 
-.bb-comparison-panel--final {
+.bt-comparison-panel--final {
   background: var(--color-surface-low);
 }
 
-.bb-comparison-field {
+.bt-comparison-field {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
 }
 
-.bb-comparison-field__label {
+.bt-comparison-field__label {
   font-family: var(--font-label);
   font-size: var(--type-label-compact-size);
   letter-spacing: var(--tracking-label-compact);
@@ -157,69 +157,69 @@
   color: var(--color-text-muted);
 }
 
-.bb-comparison-field__value {
+.bt-comparison-field__value {
   color: var(--color-text-primary);
 }
 
-.bb-comparison-field__value.is-struck {
+.bt-comparison-field__value.is-struck {
   opacity: 0.72;
   text-decoration: line-through;
 }
 
-.bb-comparison-field__value.is-final {
+.bt-comparison-field__value.is-final {
   color: var(--color-accent-soft);
   font-weight: 700;
 }
 
-.bb-comparison-panel--final .bb-comparison-field__value {
+.bt-comparison-panel--final .bt-comparison-field__value {
   color: var(--color-text-primary);
 }
 
-.bb-comparison-field--fill {
+.bt-comparison-field--fill {
   gap: var(--space-sm);
 }
 
-.bb-comparison-field--fill.is-hero {
+.bt-comparison-field--fill.is-hero {
   margin-top: var(--space-sm);
 }
 
-.bb-comparison-field__fill-value {
+.bt-comparison-field__fill-value {
   font-family: var(--font-display);
   font-size: 28px;
   color: var(--color-text-primary);
 }
 
-.bb-comparison-field__fill-value.is-final {
+.bt-comparison-field__fill-value.is-final {
   color: var(--color-accent-soft);
 }
 
-.bb-comparison-field__fill-track {
+.bt-comparison-field__fill-track {
   position: relative;
   height: 2px;
   background: var(--color-border-strong);
 }
 
-.bb-comparison-field__fill-bar {
+.bt-comparison-field__fill-bar {
   position: absolute;
   inset: 0 auto 0 0;
   background: var(--color-text-muted);
 }
 
-.bb-comparison-field__fill-bar.is-final {
+.bt-comparison-field__fill-bar.is-final {
   background: var(--color-accent);
 }
 
-.bb-resolved-card__fill {
+.bt-resolved-card__fill {
   margin: 0;
   color: var(--color-text-secondary);
 }
 
-.bb-resolved-card__fill span {
+.bt-resolved-card__fill span {
   color: var(--color-success);
   font-weight: 700;
 }
 
-.bb-centered-state {
+.bt-centered-state {
   display: flex;
   min-height: calc(100vh - 64px - 96px);
   max-width: 520px;
@@ -231,7 +231,7 @@
   text-align: center;
 }
 
-.bb-centered-state__icon {
+.bt-centered-state__icon {
   position: relative;
   display: grid;
   place-items: center;
@@ -240,8 +240,8 @@
   color: var(--color-accent-soft-glow);
 }
 
-.bb-centered-state__icon--blocked::before,
-.bb-centered-state__icon--not-found::before {
+.bt-centered-state__icon--blocked::before,
+.bt-centered-state__icon--not-found::before {
   content: '';
   position: absolute;
   inset: 0;
@@ -249,14 +249,14 @@
   border: 1px solid var(--color-accent-soft-faint);
 }
 
-.bb-centered-state__icon-core {
+.bt-centered-state__icon-core {
   width: 84px;
   height: 84px;
   border-radius: 24px;
   background: var(--color-accent-soft-shell);
 }
 
-.bb-centered-state__icon-dot {
+.bt-centered-state__icon-dot {
   position: absolute;
   top: 18px;
   width: 22px;
@@ -265,7 +265,7 @@
   background: var(--color-accent-wash-strong);
 }
 
-.bb-centered-state__icon-slash {
+.bt-centered-state__icon-slash {
   position: absolute;
   width: 72px;
   height: 10px;
@@ -274,7 +274,7 @@
   transform: rotate(45deg);
 }
 
-.bb-centered-state__file-icon {
+.bt-centered-state__file-icon {
   position: relative;
   width: 60px;
   height: 76px;
@@ -282,7 +282,7 @@
   background: var(--color-accent-soft-ghost);
 }
 
-.bb-centered-state__file-icon::before {
+.bt-centered-state__file-icon::before {
   content: '';
   position: absolute;
   right: 0;
@@ -291,7 +291,7 @@
   border-left: 20px solid transparent;
 }
 
-.bb-centered-state__file-badge {
+.bt-centered-state__file-badge {
   position: absolute;
   right: 34px;
   bottom: 28px;
@@ -301,7 +301,7 @@
   background: var(--color-accent-soft-veil);
 }
 
-.bb-centered-state__file-badge-line {
+.bt-centered-state__file-badge-line {
   position: absolute;
   right: 43px;
   bottom: 43px;
@@ -311,68 +311,68 @@
   background: var(--color-bg-canvas-overlay);
 }
 
-.bb-centered-state__file-badge-line--one {
+.bt-centered-state__file-badge-line--one {
   transform: rotate(45deg);
 }
 
-.bb-centered-state__file-badge-line--two {
+.bt-centered-state__file-badge-line--two {
   transform: rotate(-45deg);
 }
 
-.bb-centered-state__title {
+.bt-centered-state__title {
   font-size: var(--type-detail-title-size);
 }
 
-.bb-centered-state__body {
+.bt-centered-state__body {
   max-width: 420px;
 }
 
-.bb-centered-state__divider {
+.bt-centered-state__divider {
   width: 100%;
   height: 1px;
   background: var(--color-border-subtle);
 }
 
-.bb-loading-route {
+.bt-loading-route {
   color: var(--color-text-muted);
 }
 
 @media (max-width: 1279px) {
-  .bb-reports-columns,
-  .bb-reports-row {
+  .bt-reports-columns,
+  .bt-reports-row {
     grid-template-columns: 2fr 1.4fr 2fr 1.3fr 1fr;
   }
 
-  .bb-reports-columns > :nth-child(5),
-  .bb-reports-row__completed {
+  .bt-reports-columns > :nth-child(5),
+  .bt-reports-row__completed {
     display: none;
   }
 }
 
 @media (max-width: 1024px) {
-  .bb-record-card,
-  .bb-record-card--failed,
-  .bb-reviewed-grid {
+  .bt-record-card,
+  .bt-record-card--failed,
+  .bt-reviewed-grid {
     grid-template-columns: 1fr;
   }
 
-  .bb-reviewed-shell--summary {
+  .bt-reviewed-shell--summary {
     grid-template-columns: 1fr;
     gap: var(--space-lg);
   }
 
-  .bb-record-card__failed-controls,
-  .bb-comparison-grid {
+  .bt-record-card__failed-controls,
+  .bt-comparison-grid {
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 767px) {
-  .bb-reports-columns {
+  .bt-reports-columns {
     display: none;
   }
 
-  .bb-reports-row {
+  .bt-reports-row {
     grid-template-columns: 1.3fr auto;
     grid-template-areas:
       'id count'
@@ -384,32 +384,32 @@
     border: 1px solid var(--color-border-subtle);
   }
 
-  .bb-reports-row__completed {
+  .bt-reports-row__completed {
     display: none;
   }
 
-  .bb-reports-row__id {
+  .bt-reports-row__id {
     display: flex;
     grid-area: id;
   }
 
-  .bb-reports-row__status {
+  .bt-reports-row__status {
     grid-area: status;
   }
 
-  .bb-reports-row__count {
+  .bt-reports-row__count {
     grid-area: count;
   }
 
-  .bb-reports-row__operator {
+  .bt-reports-row__operator {
     grid-area: operator;
   }
 
-  .bb-reports-row__started {
+  .bt-reports-row__started {
     grid-area: started;
   }
 
-  .bb-reports-row__field-label {
+  .bt-reports-row__field-label {
     display: inline-flex;
     font-family: var(--font-label);
     font-size: var(--type-label-compact-size);
@@ -418,80 +418,80 @@
     color: var(--color-text-muted);
   }
 
-  .bb-reports-row__field-value {
+  .bt-reports-row__field-value {
     color: inherit;
   }
 
-  .bb-reports-row__operator .bb-reports-row__field-value {
+  .bt-reports-row__operator .bt-reports-row__field-value {
     font-size: var(--type-body-size);
   }
 
-  .bb-report-meta-slab,
-  .bb-processing-header,
-  .bb-inline-search,
-  .bb-review-action {
+  .bt-report-meta-slab,
+  .bt-processing-header,
+  .bt-inline-search,
+  .bt-review-action {
     grid-template-columns: 1fr;
   }
 
-  .bb-review-action,
-  .bb-review-action--enabled {
+  .bt-review-action,
+  .bt-review-action--enabled {
     justify-content: stretch;
   }
 
-  .bb-review-action .bb-button,
-  .bb-review-action--enabled .bb-button {
+  .bt-review-action .bt-button,
+  .bt-review-action--enabled .bt-button {
     width: 100%;
   }
 
-  .bb-record-card__media-slab {
+  .bt-record-card__media-slab {
     flex-direction: column;
     align-items: start;
   }
 
-  .bb-report-meta-slab,
-  .bb-processing-header,
-  .bb-comparison-card,
-  .bb-record-card__controls,
-  .bb-record-card__failed-content {
+  .bt-report-meta-slab,
+  .bt-processing-header,
+  .bt-comparison-card,
+  .bt-record-card__controls,
+  .bt-record-card__failed-content {
     padding: var(--space-xl);
   }
 
-  .bb-reviewed-shell__meta {
+  .bt-reviewed-shell__meta {
     align-items: flex-start;
     justify-content: flex-start;
     gap: var(--space-sm);
   }
 
-  .bb-metadata-line {
+  .bt-metadata-line {
     flex-direction: column;
     align-items: flex-start;
     gap: 2px;
   }
 
-  .bb-comparison-card__hero-header,
-  .bb-comparison-panel {
+  .bt-comparison-card__hero-header,
+  .bt-comparison-panel {
     padding: var(--space-lg);
   }
 
-  .bb-record-card__failed-media {
+  .bt-record-card__failed-media {
     min-height: 188px;
     padding: var(--space-lg);
   }
 
-  .bb-record-card__failed-media .bb-record-media,
-  .bb-record-card__failed-media .bb-record-media--missing {
+  .bt-record-card__failed-media .bt-record-media,
+  .bt-record-card__failed-media .bt-record-media--missing {
     min-height: 148px;
   }
 
-  .bb-fill-rail__options {
+  .bt-fill-rail__options {
     gap: 6px;
   }
 
-  .bb-fill-rail__option {
+  .bt-fill-rail__option {
     min-width: 28px;
   }
 
-  .bb-comparison-card__hero-header {
+  .bt-comparison-card__hero-header {
     align-items: start;
   }
 }

--- a/packages/dashboard/src/features/reports/styles/reports-list.css
+++ b/packages/dashboard/src/features/reports/styles/reports-list.css
@@ -1,18 +1,18 @@
-.bb-reports-list {
+.bt-reports-list {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
 }
 
-.bb-reports-columns,
-.bb-reports-row {
+.bt-reports-columns,
+.bt-reports-row {
   display: grid;
   grid-template-columns: 2fr 1.5fr 2fr 1.4fr 1.4fr 1fr;
   gap: var(--space-lg);
   align-items: center;
 }
 
-.bb-reports-columns {
+.bt-reports-columns {
   padding: 0 var(--space-2xl) var(--space-sm);
   font-family: var(--font-label);
   font-size: var(--type-label-size);
@@ -21,13 +21,13 @@
   color: var(--color-text-muted);
 }
 
-.bb-reports-rows {
+.bt-reports-rows {
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
 
-.bb-reports-row {
+.bt-reports-row {
   position: relative;
   padding: var(--space-xl) var(--space-2xl);
   border-radius: var(--radius-lg);
@@ -39,28 +39,28 @@
     border-color 180ms ease;
 }
 
-.bb-reports-row:hover {
+.bt-reports-row:hover {
   background: var(--color-surface-base);
 }
 
-.bb-reports-row:focus-visible .bb-reports-row__hoverrail {
+.bt-reports-row:focus-visible .bt-reports-row__hoverrail {
   opacity: 1;
 }
 
-.bb-reports-row__field-label {
+.bt-reports-row__field-label {
   display: none;
 }
 
-.bb-reports-row__field-value {
+.bt-reports-row__field-value {
   display: inline;
 }
 
-.bb-reports-row__field-detail {
+.bt-reports-row__field-detail {
   display: inline;
   color: var(--color-text-secondary);
 }
 
-.bb-reports-row__hoverrail {
+.bt-reports-row__hoverrail {
   position: absolute;
   left: 0;
   top: 0;
@@ -71,13 +71,13 @@
   transition: opacity 180ms ease;
 }
 
-.bb-reports-row:hover .bb-reports-row__hoverrail {
+.bt-reports-row:hover .bt-reports-row__hoverrail {
   opacity: 1;
 }
 
-.bb-reports-row__id,
-.bb-reports-row__started,
-.bb-reports-row__completed {
+.bt-reports-row__id,
+.bt-reports-row__started,
+.bt-reports-row__completed {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
@@ -86,7 +86,7 @@
   color: var(--color-text-muted);
 }
 
-.bb-reports-row__operator {
+.bt-reports-row__operator {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
@@ -95,7 +95,7 @@
   color: var(--color-text-primary);
 }
 
-.bb-reports-row__count {
+.bt-reports-row__count {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
@@ -104,19 +104,19 @@
   justify-self: end;
 }
 
-.bb-reports-row__count-value {
+.bt-reports-row__count-value {
   font-size: 18px;
   color: var(--color-accent);
   font-variant-numeric: tabular-nums;
 }
 
-.bb-reports-row__count-detail {
+.bt-reports-row__count-detail {
   color: var(--color-text-muted);
   font-size: var(--type-label-size);
   font-variant-numeric: tabular-nums;
 }
 
-.bb-status-chip {
+.bt-status-chip {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -129,84 +129,84 @@
   white-space: nowrap;
 }
 
-.bb-status-chip--created,
-.bb-status-chip--pending {
+.bt-status-chip--created,
+.bt-status-chip--pending {
   background: var(--color-surface-highest);
   color: var(--color-text-muted);
 }
 
-.bb-status-chip--processing,
-.bb-status-chip--inferred {
+.bt-status-chip--processing,
+.bt-status-chip--inferred {
   background: var(--color-surface-high);
   color: var(--color-text-secondary);
 }
 
-.bb-status-chip--unreviewed {
+.bt-status-chip--unreviewed {
   background: var(--color-surface-highest);
   color: var(--color-text-secondary);
 }
 
-.bb-status-chip--reviewed {
+.bt-status-chip--reviewed {
   background: var(--color-success-wash);
   color: var(--color-success);
 }
 
-.bb-status-chip--failed {
+.bt-status-chip--failed {
   background: var(--color-error-wash);
   color: var(--color-error);
 }
 
-.bb-surface-card {
+.bt-surface-card {
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-lg);
 }
 
-.bb-surface-card--canvas {
+.bt-surface-card--canvas {
   background: var(--color-bg-canvas);
 }
 
-.bb-surface-card--low {
+.bt-surface-card--low {
   background: var(--color-surface-low);
 }
 
-.bb-surface-card--base {
+.bt-surface-card--base {
   background: var(--color-surface-base);
 }
 
-.bb-surface-card--high {
+.bt-surface-card--high {
   background: var(--color-surface-high);
 }
 
-.bb-loading-panel,
-.bb-empty-state {
+.bt-loading-panel,
+.bt-empty-state {
   padding: var(--space-5xl);
   text-align: center;
   box-shadow: var(--shadow-ambient);
 }
 
-.bb-loading-panel__eyebrow,
-.bb-empty-state__title {
+.bt-loading-panel__eyebrow,
+.bt-empty-state__title {
   margin: 0 0 var(--space-md);
   font-family: var(--font-display);
   font-size: var(--type-section-title-size);
   color: var(--color-text-primary);
 }
 
-.bb-loading-panel__body,
-.bb-empty-state__body {
+.bt-loading-panel__body,
+.bt-empty-state__body {
   margin: 0;
   font-size: var(--type-body-size);
   color: var(--color-text-muted);
   line-height: 1.6;
 }
 
-.bb-loading-panel__actions {
+.bt-loading-panel__actions {
   display: flex;
   justify-content: center;
   margin-top: var(--space-xl);
 }
 
-.bb-empty-state__icon {
+.bt-empty-state__icon {
   margin-bottom: var(--space-2xl);
   font-size: 48px;
   color: var(--color-text-muted);

--- a/packages/dashboard/src/features/reports/styles/workbench-foundation.css
+++ b/packages/dashboard/src/features/reports/styles/workbench-foundation.css
@@ -1,4 +1,4 @@
-.bb-public-shell {
+.bt-public-shell {
   position: relative;
   min-height: 100vh;
   overflow: hidden;
@@ -7,7 +7,7 @@
     linear-gradient(180deg, var(--color-bg-app) 0%, var(--color-bg-canvas) 100%);
 }
 
-.bb-public-shell__ghost {
+.bt-public-shell__ghost {
   position: absolute;
   inset: var(--space-3xl);
   border: 0.5px solid var(--color-border-subtle);
@@ -15,7 +15,7 @@
   pointer-events: none;
 }
 
-.bb-public-shell__canvas {
+.bt-public-shell__canvas {
   position: relative;
   z-index: 1;
   min-height: 100vh;
@@ -25,18 +25,18 @@
   padding: var(--space-3xl);
 }
 
-.bb-wordmark {
+.bt-wordmark {
   display: inline-flex;
   flex-direction: column;
   align-items: flex-start;
   gap: var(--space-sm);
 }
 
-.bb-wordmark--centered {
+.bt-wordmark--centered {
   align-items: center;
 }
 
-.bb-wordmark__label {
+.bt-wordmark__label {
   font-family: var(--font-display);
   font-size: var(--type-wordmark-size);
   letter-spacing: var(--tracking-wordmark);
@@ -44,13 +44,13 @@
   color: var(--color-accent-soft);
 }
 
-.bb-wordmark__rule {
+.bt-wordmark__rule {
   width: 32px;
   height: 1px;
   background: var(--color-accent-line);
 }
 
-.bb-entry {
+.bt-entry {
   display: flex;
   max-width: 760px;
   width: 100%;
@@ -60,14 +60,14 @@
   text-align: center;
 }
 
-.bb-entry__copy {
+.bt-entry__copy {
   display: flex;
   flex-direction: column;
   gap: var(--space-2xl);
 }
 
-.bb-entry__headline,
-.bb-page-title {
+.bt-entry__headline,
+.bt-page-title {
   margin: 0;
   font-family: var(--font-display);
   font-size: var(--type-hero-size);
@@ -77,23 +77,23 @@
   color: var(--color-text-primary);
 }
 
-.bb-page-title {
+.bt-page-title {
   font-size: var(--type-page-title-size);
   color: var(--color-accent-soft);
 }
 
-.bb-page-title--detail {
+.bt-page-title--detail {
   max-width: 24ch;
   font-size: var(--type-detail-title-size);
   overflow-wrap: anywhere;
 }
 
-.bb-report-header__heading-mobile,
-.bb-report-header__mobile-support {
+.bt-report-header__heading-mobile,
+.bt-report-header__mobile-support {
   display: none;
 }
 
-.bb-report-header__mobile-support {
+.bt-report-header__mobile-support {
   margin: calc(var(--space-sm) * -1) 0 0;
   max-width: 18ch;
   font-family: var(--font-body);
@@ -103,10 +103,10 @@
   overflow-wrap: anywhere;
 }
 
-.bb-entry__support,
-.bb-reports-header__support,
-.bb-centered-state__body,
-.bb-message-panel__body {
+.bt-entry__support,
+.bt-reports-header__support,
+.bt-centered-state__body,
+.bt-message-panel__body {
   margin: 0;
   font-family: var(--font-body);
   font-size: var(--type-body-large-size);
@@ -114,19 +114,19 @@
   color: var(--color-text-muted);
 }
 
-.bb-entry__support {
+.bt-entry__support {
   max-width: 560px;
 }
 
-.bb-entry__actions,
-.bb-centered-state__actions {
+.bt-entry__actions,
+.bt-centered-state__actions {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: var(--space-xl);
 }
 
-.bb-entry__note {
+.bt-entry__note {
   margin: 0;
   font-family: var(--font-label);
   font-size: var(--type-label-size);
@@ -135,7 +135,7 @@
   color: var(--color-text-muted-soft);
 }
 
-.bb-button {
+.bt-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -157,52 +157,52 @@
     opacity 180ms ease;
 }
 
-.bb-button:hover {
+.bt-button:hover {
   transform: translateY(-1px);
 }
 
-.bb-button:focus-visible,
-.bb-select:focus-visible,
-.bb-input:focus-visible,
-.bb-reports-row:focus-visible {
+.bt-button:focus-visible,
+.bt-select:focus-visible,
+.bt-input:focus-visible,
+.bt-reports-row:focus-visible {
   outline: 2px solid var(--color-accent-soft);
   outline-offset: 2px;
 }
 
-.bb-button:disabled {
+.bt-button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
   transform: none;
 }
 
-.bb-button--full {
+.bt-button--full {
   width: 100%;
 }
 
-.bb-button--primary {
+.bt-button--primary {
   background: linear-gradient(45deg, var(--color-accent-soft), var(--color-accent));
   color: var(--color-accent-ink);
   box-shadow: 0 4px 20px var(--color-accent-glow);
 }
 
-.bb-button--secondary {
+.bt-button--secondary {
   background: var(--color-surface-highest);
   color: var(--color-text-secondary);
   border-color: var(--color-border-subtle);
 }
 
-.bb-button--ghost {
+.bt-button--ghost {
   background: transparent;
   color: var(--color-accent-soft);
   border-color: var(--color-border-subtle);
 }
 
-.bb-workbench-shell {
+.bt-workbench-shell {
   min-height: 100vh;
   background: var(--color-bg-app);
 }
 
-.bb-workbench-topbar {
+.bt-workbench-topbar {
   position: relative;
   display: grid;
   grid-template-columns: 40px 1fr 40px;
@@ -214,7 +214,7 @@
   border-bottom: 1px solid var(--color-border-subtle);
 }
 
-.bb-workbench-topbar__back {
+.bt-workbench-topbar__back {
   justify-self: start;
   width: auto;
   height: auto;
@@ -225,17 +225,17 @@
   color: var(--color-accent-soft);
 }
 
-.bb-workbench-topbar__back:hover {
+.bt-workbench-topbar__back:hover {
   transform: none;
   color: var(--color-text-primary);
 }
 
-.bb-workbench-topbar__spacer {
+.bt-workbench-topbar__spacer {
   width: 24px;
   height: 24px;
 }
 
-.bb-workbench-topbar__mode {
+.bt-workbench-topbar__mode {
   position: absolute;
   top: 50%;
   right: var(--space-3xl);
@@ -253,82 +253,82 @@
   transform: translateY(-50%);
 }
 
-.bb-workbench-canvas {
+.bt-workbench-canvas {
   max-width: 1280px;
   width: 100%;
   margin: 0 auto;
   padding: 48px 32px 96px;
 }
 
-.bb-reports-screen,
-.bb-report-screen {
+.bt-reports-screen,
+.bt-report-screen {
   display: flex;
   flex-direction: column;
   gap: var(--space-4xl);
 }
 
-.bb-reports-header {
+.bt-reports-header {
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
 }
 
-.bb-reports-header__copy {
+.bt-reports-header__copy {
   max-width: 760px;
 }
 
 @media (max-width: 767px) {
-  .bb-public-shell__canvas,
-  .bb-workbench-canvas {
+  .bt-public-shell__canvas,
+  .bt-workbench-canvas {
     padding: 24px 20px 72px;
   }
 
-  .bb-workbench-topbar {
+  .bt-workbench-topbar {
     grid-template-columns: 32px 1fr 32px;
     gap: var(--space-md);
     height: 60px;
     padding: 0 14px;
   }
 
-  .bb-workbench-topbar__mode {
+  .bt-workbench-topbar__mode {
     right: 14px;
     min-width: 56px;
     padding: 5px 8px;
     font-size: 11px;
   }
 
-  .bb-page-title {
+  .bt-page-title {
     font-size: 52px;
   }
 
-  .bb-page-title--detail {
+  .bt-page-title--detail {
     max-width: 14ch;
     font-size: 42px;
   }
 
-  .bb-report-header__heading-desktop {
+  .bt-report-header__heading-desktop {
     display: none;
   }
 
-  .bb-report-header__heading-mobile,
-  .bb-report-header__mobile-support {
+  .bt-report-header__heading-mobile,
+  .bt-report-header__mobile-support {
     display: block;
   }
 
-  .bb-report-header__mobile-support {
+  .bt-report-header__mobile-support {
     max-width: 100%;
   }
 
-  .bb-entry__support,
-  .bb-reports-header__support,
-  .bb-centered-state__body,
-  .bb-message-panel__body {
+  .bt-entry__support,
+  .bt-reports-header__support,
+  .bt-centered-state__body,
+  .bt-message-panel__body {
     font-size: var(--type-body-size);
   }
 }
 
 @media (min-width: 900px) {
-  .bb-reports-header {
+  .bt-reports-header {
     flex-direction: row;
     align-items: end;
     justify-content: space-between;


### PR DESCRIPTION
## Summary
- rename dashboard-facing BarBack branding to BarTools across the web app
- replace the internal `bb-` dashboard prefix family with `bt-` so the old shorthand is fully removed
- update dashboard specs, coordination docs, and golden-set HTML references to match the new name

## Why
The product name changed to `BarTools`, and the dashboard still carried the old `BarBack` branding in both user-facing copy and internal dashboard-specific naming.

## Impact
- the web dashboard wordmark and related product copy now use `BarTools`
- dashboard-local implementation prefixes no longer encode the old brand name
- local design/coordination references inside `packages/dashboard` stay aligned with the shipped branding

## Validation
- [x] `bun --filter @bartools/dashboard lint`
- [x] `bun --filter @bartools/dashboard typecheck`
- [x] `bun run test`

## Notes
- no PNGs, binary assets, or large blob-style files were added in this change
- this PR intentionally includes the dashboard package's coordination and golden-set reference files so the package no longer contains stale branding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated styling class names across all dashboard components and feature modules.
  * Refreshed product branding terminology in templates and documentation.
  * Comprehensive namespace updates to shell, workbench, reports, and backstock user interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->