### PR TITLE
fix(backend): unblock mobile POST /reports

### DIFF
--- a/packages/backend/src/create-report-schema.test.ts
+++ b/packages/backend/src/create-report-schema.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { createReportSchema } from './report-lifecycle';
+
+// Locks in the contract that POST /reports accepts what the mobile client
+// actually sends — including null locationId and the all-zeros placeholder
+// UUIDs that Postgres accepts but Zod 4's strict .uuid() rejects.
+describe('createReportSchema', () => {
+  // Mobile-client defaults. Third group "0000" has no valid RFC 4122 version
+  // nibble, so these fail z.string().uuid() but are valid Postgres UUIDs.
+  const MOBILE_USER = '00000000-0000-0000-0000-000000000001';
+  const MOBILE_VENUE = '00000000-0000-0000-0000-000000000001';
+  const RFC_V4 = '550e8400-e29b-41d4-a716-446655440000';
+
+  test('accepts mobile-client payload with locationId omitted', () => {
+    const result = createReportSchema.safeParse({
+      userId: MOBILE_USER,
+      venueId: MOBILE_VENUE,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts mobile-client payload with locationId: null', () => {
+    const result = createReportSchema.safeParse({
+      userId: MOBILE_USER,
+      venueId: MOBILE_VENUE,
+      locationId: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts RFC 4122 v4 UUIDs', () => {
+    const result = createReportSchema.safeParse({
+      userId: RFC_V4,
+      venueId: RFC_V4,
+      locationId: RFC_V4,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects payload with non-UUID locationId', () => {
+    const result = createReportSchema.safeParse({
+      userId: MOBILE_USER,
+      venueId: MOBILE_VENUE,
+      locationId: 'not-a-uuid',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects payload with wrong-length user id', () => {
+    const result = createReportSchema.safeParse({
+      userId: '12345',
+      venueId: MOBILE_VENUE,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects payload missing userId', () => {
+    const result = createReportSchema.safeParse({ venueId: MOBILE_VENUE });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects payload missing venueId', () => {
+    const result = createReportSchema.safeParse({ userId: MOBILE_USER });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/backend/src/report-lifecycle.ts
+++ b/packages/backend/src/report-lifecycle.ts
@@ -4,10 +4,26 @@ import { db } from './db';
 import { inferenceJobs, reportRecords, reports, scans } from './schema';
 import { getBucketName } from './storage';
 
+// Permissive UUID format — matches Postgres's canonical UUID text representation
+// (8-4-4-4-12 hex). Zod 4's built-in `.uuid()` adds an RFC 4122 variant/version
+// check that rejects e.g. "00000000-0000-0000-0000-000000000001" (used by the
+// mobile client as a placeholder user/venue id), even though Postgres accepts
+// and round-trips it. Matching Postgres's permissiveness keeps the validator
+// in sync with what the database will actually store.
+const uuidLike = z
+  .string()
+  .regex(
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
+    { message: 'invalid UUID format' },
+  );
+
 export const createReportSchema = z.object({
-  userId: z.string().uuid(),
-  venueId: z.string().uuid(),
-  locationId: z.string().uuid().optional(),
+  userId: uuidLike,
+  venueId: uuidLike,
+  // Accept both `null` (client sends when no location picked) and `undefined`
+  // (field omitted entirely). `.optional()` alone rejected `null`, causing
+  // every POST /reports from the mobile client to 400.
+  locationId: uuidLike.nullish(),
 });
 
 export type ReportScanInferencePayload = {

--- a/packages/backend/src/seed.ts
+++ b/packages/backend/src/seed.ts
@@ -26,6 +26,13 @@ const DEMO_VENUE = 'Demo Bar';
 const DEMO_LOCATIONS = ['Main Bar', 'Backstock'] as const;
 const DEMO_REPORT_NOTES_PREFIX = 'demo-seed';
 
+// The mobile client (packages/mobile/lib/config.ts) ships with these hardcoded
+// IDs as placeholders until real auth lands. Seeding the demo tenant with the
+// same UUIDs lets fresh installs hit POST /reports without a foreign-key
+// violation on users/venues.
+export const MOBILE_DEFAULT_USER_ID = '00000000-0000-0000-0000-000000000001';
+export const MOBILE_DEFAULT_VENUE_ID = '00000000-0000-0000-0000-000000000001';
+
 // ─── Bottle catalog ─────────────────────────────────────────────────
 
 const SIZE_MAP: Record<string, number> = {
@@ -118,7 +125,7 @@ export async function seedDemoTenant(): Promise<{ ids: DemoIds; created: number 
 
   const [userRow] = await db
     .insert(users)
-    .values({ email: DEMO_EMAIL, displayName: 'Demo User' })
+    .values({ id: MOBILE_DEFAULT_USER_ID, email: DEMO_EMAIL, displayName: 'Demo User' })
     .onConflictDoNothing({ target: users.email })
     .returning({ id: users.id });
 
@@ -142,7 +149,7 @@ export async function seedDemoTenant(): Promise<{ ids: DemoIds; created: number 
   } else {
     const [venueRow] = await db
       .insert(venues)
-      .values({ name: DEMO_VENUE })
+      .values({ id: MOBILE_DEFAULT_VENUE_ID, name: DEMO_VENUE })
       .returning({ id: venues.id });
     venueId = venueRow.id;
     created++;


### PR DESCRIPTION
## Summary

Fixes three stacked issues that made every `POST /reports` from the TestFlight mobile client return `400 invalid_report_payload`.

1. **Zod `.uuid()` rejects the mobile client's placeholder IDs.** `packages/mobile/lib/config.ts` ships with `DEFAULT_USER_ID` and `DEFAULT_VENUE_ID` both set to `00000000-0000-0000-0000-000000000001`. Zod 4's `.uuid()` enforces RFC 4122 version bits in the third group (`[1-8]`), so it rejects these values — even though Postgres's `uuid` column type accepts and round-trips them unchanged. Replaced `.uuid()` with a Postgres-permissive `uuidLike` helper (`[0-9a-fA-F]{8}-…-[0-9a-fA-F]{12}`) so the validator matches the database's actual permissiveness.

2. **`.optional()` rejected `null`.** The mobile client always includes the `locationId` key in the JSON body, coercing `undefined` to `null` before serialization. `.optional()` only accepts missing keys or `undefined`, so the null was rejected. Switched to `.nullish()` to accept both.

3. **Demo seed didn't produce rows with the mobile's placeholder UUIDs.** Even after the schema fixes, the insert would FK-violate because no rows with those IDs existed. `seedDemoTenant` now pins the demo user + venue to `MOBILE_DEFAULT_USER_ID` / `MOBILE_DEFAULT_VENUE_ID` (exported constants) so running `bun run packages/backend/src/seed.ts` on a fresh staging DB resolves the mobile client's defaults end-to-end.

Trace of the original failure for reference: Cloud Run logs showed `POST /reports` returning 400 in ~66 ms. iOS Console.app on the TestFlight build confirmed `request_bytes=126` (exactly the size of the JSON body with the placeholder UUIDs + `locationId: null`).

## Test plan

- [x] `bunx tsc -p packages/backend --noEmit` clean
- [x] 7 new unit tests in `create-report-schema.test.ts` pass against the loose UUID schema — covers mobile placeholder IDs, null locationId, RFC v4 UUIDs, and rejection cases. DB-free.
- [x] Full `bun test packages/backend/src/` run: 19 pass, 3 fail. The 3 failures (`addReportPhotos idempotency`) are pre-existing on `main` (drizzle-kit `pushSchema` race in test-setup) — unrelated to this change.
- [ ] Deploy to staging Cloud Run
- [ ] Run `bun run packages/backend/src/seed.ts` against staging Neon to create the placeholder rows
- [ ] Confirm mobile TestFlight build can submit a report → backend returns 201 Created with the new row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for report schema validation covering various input scenarios.

* **Bug Fixes**
  * Enhanced UUID format validation for improved data consistency.
  * Location ID field now properly accepts null values in addition to standard formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->