### PR TITLE
feat(mobile): defer manual entry + allow early confirm

### DIFF
--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -28,7 +28,7 @@
         "NSMicrophoneUsageDescription": "BarTools does not record audio. This key is required by the camera framework used to photograph bottles.",
         "ITSAppUsesNonExemptEncryption": false
       },
-      "buildNumber": "19"
+      "buildNumber": "21"
     },
     "android": {
       "package": "com.bartools.barback",

--- a/packages/mobile/app/review.tsx
+++ b/packages/mobile/app/review.tsx
@@ -65,6 +65,26 @@ export default function ReviewScreen() {
     setSearchTarget(null)
   }, [searchTarget])
 
+  // Used when the user can't find a match in the search modal and opts to
+  // create a new catalog entry. Seeds a minimal manual bottle with the typed
+  // name; the user can then refine category/size in the inline editor.
+  const handleAddAsNew = useCallback((name: string) => {
+    if (!searchTarget) return
+    setEdits((prev) => ({
+      ...prev,
+      [searchTarget]: {
+        ...prev[searchTarget],
+        bottleId: undefined,
+        bottleName: undefined,
+        bottle: {
+          name,
+          category: 'other' as ItemCategory,
+        },
+      },
+    }))
+    setSearchTarget(null)
+  }, [searchTarget])
+
   const handleManualBottleChange = useCallback((
     recordId: string,
     patch: { name?: string; category?: ItemCategory; sizeMlText?: string },
@@ -181,7 +201,36 @@ export default function ReviewScreen() {
               />
             </View>
           ) : null}
-          {!isViewMode && !hasCatalogBottle ? (
+          {/* Unidentified record (no catalog match, user hasn't confirmed a manual
+              entry yet): show a compact "tap to choose" tile that opens the fuzzy
+              search modal. The modal carries an "Add as new" affordance so the
+              user only drops into manual entry once they've confirmed the bottle
+              truly isn't in the catalog. */}
+          {!isViewMode && !hasCatalogBottle && !edit?.bottle ? (
+            item.status === 'pending' ? (
+              // Still running VLM — don't prompt yet; the status is unknown,
+              // not "unidentified".
+              <View style={[styles.unidentifiedBanner, { borderColor: theme.outline }]}>
+                <ActivityIndicator size="small" color={theme.outline} />
+                <Text style={[styles.unidentifiedText, { color: theme.outline }]}>
+                  Identifying bottle...
+                </Text>
+              </View>
+            ) : (
+              <Pressable
+                onPress={() => setSearchTarget(item.id)}
+                style={[styles.unidentifiedBanner, { borderColor: theme.primary }]}
+                accessibilityRole="button"
+                accessibilityLabel="Identify this bottle"
+              >
+                <MaterialCommunityIcons name="help-circle-outline" size={18} color={theme.primary} />
+                <Text style={[styles.unidentifiedText, { color: theme.primary }]}>
+                  Bottle not identified — tap to choose
+                </Text>
+              </Pressable>
+            )
+          ) : null}
+          {!isViewMode && !hasCatalogBottle && edit?.bottle ? (
             <View style={[styles.manualEditor, { backgroundColor: theme.surfaceContainer }]}>
               <Text style={[styles.manualLabel, { color: theme.primary }]}>
                 Manual Bottle
@@ -300,8 +349,10 @@ export default function ReviewScreen() {
         </View>
       ) : null}
 
-      {/* Bottom action */}
-      {isReady && !isViewMode ? (
+      {/* Bottom action — appears as soon as every record has a bottle resolved,
+          whether by VLM or manual entry, so power users can confirm ahead of
+          the backend finishing. */}
+      {canSubmit && !isViewMode ? (
         <View style={[styles.bottomAction, { backgroundColor: theme.surfaceContainerLow }]}>
           <Pressable
             style={({ pressed }) => [
@@ -337,6 +388,7 @@ export default function ReviewScreen() {
         visible={searchTarget !== null}
         onDismiss={() => setSearchTarget(null)}
         onSelect={handleBottleSelect}
+        onAddAsNew={handleAddAsNew}
       />
 
       {/* Image lightbox — tap card to view, tap again to dismiss */}
@@ -482,6 +534,23 @@ const styles = StyleSheet.create({
   },
   fillEditor: {
     marginTop: 4,
+  },
+  unidentifiedBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    padding: 12,
+    marginTop: 4,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+  },
+  unidentifiedText: {
+    fontFamily: 'SpaceGrotesk',
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    flex: 1,
   },
   manualEditor: {
     padding: 12,

--- a/packages/mobile/components/BottleSearchModal.tsx
+++ b/packages/mobile/components/BottleSearchModal.tsx
@@ -9,9 +9,10 @@ interface BottleSearchModalProps {
   visible: boolean
   onDismiss: () => void
   onSelect: (bottle: BottleSearchResult) => void
+  onAddAsNew?: (name: string) => void
 }
 
-export function BottleSearchModal({ visible, onDismiss, onSelect }: Readonly<BottleSearchModalProps>) {
+export function BottleSearchModal({ visible, onDismiss, onSelect, onAddAsNew }: Readonly<BottleSearchModalProps>) {
   const theme = useTheme()
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<BottleSearchResult[]>([])
@@ -140,6 +141,24 @@ export function BottleSearchModal({ visible, onDismiss, onSelect }: Readonly<Bot
               }
             />
 
+            {/* Add as new — only when caller opted in and user has typed a name */}
+            {onAddAsNew && query.trim().length > 0 ? (
+              <Pressable
+                style={({ pressed }) => [
+                  styles.addAsNewRow,
+                  { borderColor: theme.tertiary, opacity: pressed ? 0.7 : 1 },
+                ]}
+                onPress={() => onAddAsNew(query.trim())}
+                accessibilityRole="button"
+                accessibilityLabel={`Add ${query.trim()} as new bottle`}
+              >
+                <MaterialCommunityIcons name="plus-circle-outline" size={18} color={theme.tertiary} />
+                <Text style={[styles.addAsNewText, { color: theme.tertiary }]} numberOfLines={1}>
+                  Add &ldquo;{query.trim()}&rdquo; as new bottle
+                </Text>
+              </Pressable>
+            ) : null}
+
             {/* Dismiss */}
             <Pressable onPress={onDismiss} style={styles.dismissButton}>
               <Text style={[styles.dismissText, { color: theme.outline }]}>Cancel</Text>
@@ -185,4 +204,20 @@ const styles = StyleSheet.create({
   emptyText: { fontFamily: 'Manrope', fontSize: 13, textAlign: 'center', paddingVertical: 24 },
   dismissButton: { paddingVertical: 12, alignItems: 'center' },
   dismissText: { fontFamily: 'SpaceGrotesk', fontSize: 12, fontWeight: '500', textTransform: 'uppercase', letterSpacing: 3 },
+  addAsNewRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderWidth: 1,
+    borderRadius: 8,
+    borderStyle: 'dashed',
+  },
+  addAsNewText: {
+    fontFamily: 'Manrope',
+    fontSize: 14,
+    fontWeight: '600',
+    flex: 1,
+  },
 })


### PR DESCRIPTION
## Summary
- Records without a VLM catalog match now show a compact *"Bottle not identified — tap to choose"* tile (pending records get an *"Identifying bottle..."* spinner) instead of dropping straight into the manual-entry form. The tile opens the existing fuzzy-search bottom sheet.
- `BottleSearchModal` gains an optional `onAddAsNew` prop: when the user has typed a query, a dashed *"Add '<query>' as new bottle"* row appears below the results so users explicitly confirm a catalog miss before the manual category/size form expands.
- Confirm-review bar now renders whenever `canSubmit` is true — every record has either a backend-resolved `bottleId` or a valid user-supplied manual bottle — instead of waiting for the full stream to finish. Lets power users submit ahead of inference completing.

## Test plan
- [ ] Capture a batch; pending records show the spinner tile, not the manual editor.
- [ ] Failed/unmatched records show the copper "tap to choose" tile.
- [ ] Tapping the tile opens the search modal; picking a catalog bottle links it.
- [ ] Typing a name with no matches → "Add … as new" row appears; tapping seeds the manual editor.
- [ ] Confirm bar shows up as soon as every visible record has a bottle (manual or VLM), without waiting for stream ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to manually create a new bottle entry when searching if the bottle isn't found in the catalog
  * Improved UI feedback for unidentified bottles with search and manual entry options

* **Chores**
  * Updated iOS build configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->