### PR TITLE
Tighten live backstock create flow

### DIFF
--- a/packages/dashboard/src/app/router.test.tsx
+++ b/packages/dashboard/src/app/router.test.tsx
@@ -16,7 +16,7 @@ describe('app routing', () => {
   ])('redirects %s back to the reports workbench', async (route) => {
     renderAppRoutes({ initialEntries: [route] })
 
-    expect(await screen.findByRole('heading', { name: 'Reports' })).toBeInTheDocument()
+    expect(await screen.findByText('created')).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Inventory' })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Low Stock' })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Settings' })).not.toBeInTheDocument()

--- a/packages/dashboard/src/features/backstock/components/backstock-report-create-screen.tsx
+++ b/packages/dashboard/src/features/backstock/components/backstock-report-create-screen.tsx
@@ -86,6 +86,7 @@ export function BackstockReportCreateScreen({
   const selectedLocation =
     locationOptions.find((location) => location.id === locationId) ?? null
   const hasValidDraft = draftSummary.skuCount > 0
+  const photoStartDisabled = !!photoGenerationBlockedMessage
   const workflowStage = buildBackstockWorkflowStage({
     hasValidDraft,
     locationId,
@@ -106,7 +107,11 @@ export function BackstockReportCreateScreen({
   return (
     <div className="bt-backstock-screen">
       <BackstockReportHeader
-        support="Count sealed bottles in one backstock location. Start from photos or enter line items directly."
+        support={
+          photoStartDisabled
+            ? 'Count sealed bottles in one backstock location. Enter line items directly for now.'
+            : 'Count sealed bottles in one backstock location. Start from photos or enter line items directly.'
+        }
         title="New Backstock Report"
       />
       <BackstockWorkflowRail
@@ -132,6 +137,7 @@ export function BackstockReportCreateScreen({
         locationOptions={locationOptions}
         onLocationChange={onLocationChange}
         onStartModeChange={onStartModeChange}
+        photoStartDisabled={photoStartDisabled}
         startMode={startMode}
       />
       {startMode === 'photo' ? (
@@ -189,10 +195,10 @@ function BackstockWorkflowRail({
     {
       label: 'Stage Photos',
       support:
-        startMode === 'photo'
-          ? photoGenerationBlocked
-            ? 'Queue shelf photos while draft generation is pending backend work.'
-            : 'Queue shelf photos for the first draft.'
+        photoGenerationBlocked
+          ? 'Photo-assisted draft generation is not available yet in live mode.'
+          : startMode === 'photo'
+          ? 'Queue shelf photos for the first draft.'
           : 'Optional when you want to start manually.',
     },
     { label: 'Review Draft', support: 'Fix grouped counts and product matches.' },
@@ -296,12 +302,14 @@ function BackstockSetupCard({
   locationOptions,
   onLocationChange,
   onStartModeChange,
+  photoStartDisabled,
   startMode,
 }: {
   locationId: string
   locationOptions: ReadonlyArray<BackstockLocationOption>
   onLocationChange: (locationId: string) => void
   onStartModeChange: (mode: BackstockStartMode) => void
+  photoStartDisabled: boolean
   startMode: BackstockStartMode
 }) {
   return (
@@ -310,7 +318,9 @@ function BackstockSetupCard({
         <div>
           <h2 className="bt-backstock-card__title">Report Setup</h2>
           <p className="bt-backstock-card__support">
-            Choose one location and the fastest starting point for this count.
+            {photoStartDisabled
+              ? 'Choose one location. Manual entry is available now.'
+              : 'Choose one location and the fastest starting point for this count.'}
           </p>
         </div>
       </div>
@@ -335,10 +345,11 @@ function BackstockSetupCard({
             <button
               aria-pressed={startMode === 'photo'}
               className={`bt-backstock-mode-toggle__option${startMode === 'photo' ? ' is-active' : ''}`}
+              disabled={photoStartDisabled}
               onClick={() => onStartModeChange('photo')}
               type="button"
             >
-              Use Photos
+              Photo-Assisted
             </button>
             <button
               aria-pressed={startMode === 'manual'}

--- a/packages/dashboard/src/features/backstock/routes/backstock-report-create-route.test.tsx
+++ b/packages/dashboard/src/features/backstock/routes/backstock-report-create-route.test.tsx
@@ -1,10 +1,15 @@
 import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createFixtureReportsClient } from '../../../lib/reports/client'
 import { renderAppRoutes } from '../../../test/test-utils'
 
+beforeEach(() => {
+  vi.useRealTimers()
+})
+
 afterEach(() => {
+  vi.useRealTimers()
   window.sessionStorage.clear()
   vi.unstubAllEnvs()
 })
@@ -245,16 +250,19 @@ describe('Live backstock route guards', () => {
     })
 
     expect(await screen.findByRole('combobox', { name: 'Backstock Location' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Enter Manually' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    expect(screen.getByRole('button', { name: 'Photo-Assisted' })).toBeDisabled()
+    expect(screen.queryByLabelText('Choose Photos')).not.toBeInTheDocument()
     expect(
       screen.getByText(
         'Live backstock creation is still waiting on backend support. Photo-generated drafts and final submission are not connected yet.',
       ),
     ).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Generation Pending' })).toBeDisabled()
     expect(
-      screen.getByText(
-        'Photo-generated drafts need backend uploads and grouping before they can run here.',
-      ),
+      screen.getByText('Photo-assisted draft generation is not available yet in live mode.'),
     ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Submission Pending' })).toBeDisabled()
     expect(

--- a/packages/dashboard/src/features/backstock/routes/backstock-report-create-route.tsx
+++ b/packages/dashboard/src/features/backstock/routes/backstock-report-create-route.tsx
@@ -7,17 +7,19 @@ import type {
   BackstockCreateLoadResult,
   BackstockCreateRouteData,
 } from '../../../lib/reports/route-loaders'
+import { useReportsClient } from '../../../lib/reports/provider'
 import { BackstockReportCreateScreen } from '../components/backstock-report-create-screen'
 import { useBackstockReportCreateState } from './use-backstock-report-create-state'
 
 export function BackstockReportCreateRoute() {
   const { loadResult } = useLoaderData() as BackstockCreateRouteData
+  const client = useReportsClient()
 
   return (
     <Suspense
       fallback={
         <DelayedFallback>
-          <BackstockRouteLoadingScreen />
+          <BackstockRouteLoadingScreen photoStartDisabled={client.readiness.backendEnabled} />
         </DelayedFallback>
       }
     >
@@ -54,15 +56,20 @@ function ResolvedBackstockReportCreateRoute({
   return <BackstockReportCreateScreen {...backstockState} locationOptions={loadResult.locations} />
 }
 
-function BackstockRouteLoadingScreen() {
+function BackstockRouteLoadingScreen({
+  photoStartDisabled,
+}: {
+  photoStartDisabled: boolean
+}) {
   return (
     <div className="bt-backstock-screen">
       <section className="bt-backstock-header">
         <p className="bt-backstock-header__eyebrow">Reports</p>
         <h1 className="bt-page-title">New Backstock Report</h1>
         <p className="bt-reports-header__support">
-          Count sealed bottles in one backstock location. Start from photos or enter line
-          items directly.
+          {photoStartDisabled
+            ? 'Count sealed bottles in one backstock location. Enter line items directly for now.'
+            : 'Count sealed bottles in one backstock location. Start from photos or enter line items directly.'}
         </p>
       </section>
 

--- a/packages/dashboard/src/features/backstock/routes/use-backstock-report-create-state.ts
+++ b/packages/dashboard/src/features/backstock/routes/use-backstock-report-create-state.ts
@@ -25,12 +25,12 @@ type BackstockIntegrationState = ReturnType<typeof createBackstockIntegrationSta
 
 export function useBackstockReportCreateState() {
   const reportsClient = useReportsClient()
-  const restoredDraft = useMemo(() => loadPersistedBackstockDraft(), [])
-  const formState = useBackstockDraftState(restoredDraft)
   const integrationState = useMemo(
     () => createBackstockIntegrationState(reportsClient.readiness.backendEnabled),
     [reportsClient.readiness.backendEnabled],
   )
+  const restoredDraft = useMemo(() => loadPersistedBackstockDraft(), [])
+  const formState = useBackstockDraftState(restoredDraft, integrationState)
   const submissionReadiness = useMemo(
     () => buildBackstockSubmissionReadiness(formState.lineItems),
     [formState.lineItems],
@@ -47,7 +47,7 @@ export function useBackstockReportCreateState() {
     formState.submittedSummary === null &&
     (formState.locationId !== '' ||
       formState.sourcePhotos.length > 0 ||
-      formState.startMode !== 'photo' ||
+      formState.startMode !== integrationState.defaultStartMode ||
       formState.lineItems.some((lineItem) => !isBlankBackstockDraftLineItem(lineItem)))
 
   useBackstockDraftProtection({
@@ -211,6 +211,9 @@ function createBackstockDraftActions({
   }
 
   function handleStartModeChange(mode: BackstockStartMode) {
+    if (mode === 'photo' && !integrationState.photoDraftGenerationEnabled) {
+      return
+    }
     formState.setDraftStatusMessage(null)
     formState.setStartMode(mode)
   }
@@ -321,20 +324,29 @@ function submitBackstockDraft({
   formState.setSubmittedSummary(submissionReadiness.summary)
 }
 
-function useBackstockDraftState(restoredDraft: RestoredBackstockDraft | null) {
+function useBackstockDraftState(
+  restoredDraft: RestoredBackstockDraft | null,
+  integrationState: BackstockIntegrationState,
+) {
   const [startMode, setStartMode] = useState<BackstockStartMode>(
-    () => restoredDraft?.startMode ?? 'photo',
+    () =>
+      integrationState.photoDraftGenerationEnabled
+        ? restoredDraft?.startMode ?? integrationState.defaultStartMode
+        : 'manual',
   )
   const [locationId, setLocationId] = useState(() => restoredDraft?.locationId ?? '')
   const [sourcePhotos, setSourcePhotos] = useState<BackstockSourcePhoto[]>(
-    () => restoredDraft?.sourcePhotos ?? [],
+    () => (integrationState.photoDraftGenerationEnabled ? restoredDraft?.sourcePhotos ?? [] : []),
   )
   const [lineItems, setLineItems] = useState<BackstockDraftLineItem[]>(
     () => restoredDraft?.lineItems ?? [createBackstockDraftLineItem()],
   )
   const [generatingDraft, setGeneratingDraft] = useState(false)
   const [generatedPhotoSignature, setGeneratedPhotoSignature] = useState<string | null>(
-    () => restoredDraft?.generatedPhotoSignature ?? null,
+    () =>
+      integrationState.photoDraftGenerationEnabled
+        ? restoredDraft?.generatedPhotoSignature ?? null
+        : null,
   )
   const [submittedSummary, setSubmittedSummary] = useState<SubmittedBackstockSummary | null>(null)
   const [draftStatusMessage, setDraftStatusMessage] = useState<string | null>(() =>
@@ -364,6 +376,7 @@ function useBackstockDraftState(restoredDraft: RestoredBackstockDraft | null) {
 function createBackstockIntegrationState(backendEnabled: boolean) {
   if (!backendEnabled) {
     return {
+      defaultStartMode: 'photo' as const,
       integrationNotice: null,
       photoDraftGenerationEnabled: true,
       photoGenerationBlockedMessage: null,
@@ -373,6 +386,7 @@ function createBackstockIntegrationState(backendEnabled: boolean) {
   }
 
   return {
+    defaultStartMode: 'manual' as const,
     integrationNotice:
       'Live backstock creation is still waiting on backend support. Photo-generated drafts and final submission are not connected yet.',
     photoDraftGenerationEnabled: false,

--- a/packages/dashboard/src/features/backstock/styles/backstock-report.css
+++ b/packages/dashboard/src/features/backstock/styles/backstock-report.css
@@ -208,6 +208,11 @@
   color: var(--color-accent-soft);
 }
 
+.bt-backstock-mode-toggle__option:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
 .bt-backstock-mode-toggle__option:focus-visible {
   outline: 2px solid var(--color-accent-soft);
   outline-offset: 2px;

--- a/packages/dashboard/src/features/reports/components/report-comparison-record-card.tsx
+++ b/packages/dashboard/src/features/reports/components/report-comparison-record-card.tsx
@@ -22,22 +22,17 @@ export function ComparisonRecordCard({
       className={`bt-comparison-card${variant === 'hero' ? ' bt-comparison-card--hero' : ''}`}
       tone="low"
     >
-      {variant === 'hero' ? (
-        <div className="bt-comparison-card__hero-header">
-          <div className="bt-comparison-card__hero-media">
-            <RecordMedia record={record} />
-          </div>
-          <div className="bt-comparison-card__record-title">
-            <h2>{record.bottleName}</h2>
-            <p>{record.category ?? 'Uncategorized'}</p>
-          </div>
+      <div
+        className={`bt-comparison-card__header${variant === 'hero' ? ' bt-comparison-card__hero-header' : ''}`}
+      >
+        <div className="bt-comparison-card__media">
+          <RecordMedia record={record} />
         </div>
-      ) : (
         <div className="bt-comparison-card__record-title">
           <h2>{record.bottleName}</h2>
           <p>{record.category ?? 'Uncategorized'}</p>
         </div>
-      )}
+      </div>
       <div className="bt-comparison-grid">
         <ComparisonPanel
           fields={comparisonFields}

--- a/packages/dashboard/src/features/reports/components/report-processing-record.tsx
+++ b/packages/dashboard/src/features/reports/components/report-processing-record.tsx
@@ -19,13 +19,22 @@ function ResolvedProcessingRecord({ record }: { record: ReportBottleRecord }) {
     >
       <div className="bt-processing-record__media">
         {!showFallback ? (
-          <img
-            alt={record.bottleName}
-            height={96}
-            onError={handleError}
-            src={imageUrl}
-            width={72}
-          />
+          <a
+            aria-label={`Open ${record.bottleName} image in a new tab`}
+            className="bt-processing-record__media-link"
+            href={imageUrl}
+            rel="noopener noreferrer"
+            target="_blank"
+            title="Open full image in a new tab"
+          >
+            <img
+              alt={record.bottleName}
+              height={96}
+              onError={handleError}
+              src={imageUrl}
+              width={72}
+            />
+          </a>
         ) : (
           <div className="bt-processing-record__placeholder">◻</div>
         )}

--- a/packages/dashboard/src/features/reports/components/report-processing-record.tsx
+++ b/packages/dashboard/src/features/reports/components/report-processing-record.tsx
@@ -1,15 +1,31 @@
 import type { ReportBottleRecord } from '@bartools/types'
 import { SurfaceCard } from '../../../components/primitives/surface-card'
+import {
+  getReportRecordImageStateKey,
+  useReportRecordImage,
+} from './use-report-record-image'
 
 export function ProcessingRecord({ record }: { record: ReportBottleRecord }) {
+  return <ResolvedProcessingRecord key={getReportRecordImageStateKey(record)} record={record} />
+}
+
+function ResolvedProcessingRecord({ record }: { record: ReportBottleRecord }) {
+  const { handleError, imageUrl, showFallback } = useReportRecordImage(record)
+
   return (
     <SurfaceCard
       className={`bt-processing-record${record.status === 'pending' ? ' bt-processing-record--pending' : ''}`}
       tone="base"
     >
       <div className="bt-processing-record__media">
-        {record.imageUrl ? (
-          <img alt={record.bottleName} height={96} src={record.imageUrl} width={72} />
+        {!showFallback ? (
+          <img
+            alt={record.bottleName}
+            height={96}
+            onError={handleError}
+            src={imageUrl}
+            width={72}
+          />
         ) : (
           <div className="bt-processing-record__placeholder">◻</div>
         )}

--- a/packages/dashboard/src/features/reports/components/report-record-media.test.tsx
+++ b/packages/dashboard/src/features/reports/components/report-record-media.test.tsx
@@ -1,0 +1,108 @@
+import type { ReactNode } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import type { ReportBottleRecord, ReportDetail } from '@bartools/types'
+import { AppProviders } from '../../../app/providers'
+import { createFixtureReportsClient, type ReportsClient } from '../../../lib/reports/client'
+import { RecordMedia } from './report-record-media'
+import { ProcessingRecord } from './report-processing-record'
+
+const baseRecord: ReportBottleRecord = {
+  id: 'record-1',
+  bottleId: 'bottle-1',
+  imageUrl: 'https://example.com/original.jpg',
+  bottleName: 'Orphan Barrel Fanged Pursuit',
+  category: 'bourbon',
+  volumeMl: 750,
+  fillPercent: 50,
+  corrected: false,
+  status: 'inferred',
+}
+
+describe('RecordMedia', () => {
+  it('shows the calm fallback when the image request fails outside a live report route', () => {
+    renderWithRoute(<RecordMedia record={baseRecord} />, {
+      initialEntries: ['/__review/report/unreviewed'],
+      routePath: '/__review/report/unreviewed',
+    })
+
+    fireEvent.error(screen.getByRole('img', { name: /Orphan Barrel Fanged Pursuit/i }))
+
+    expect(screen.getByText('Image unavailable')).toBeInTheDocument()
+    expect(screen.queryByRole('img', { name: /Orphan Barrel Fanged Pursuit/i })).not.toBeInTheDocument()
+  })
+
+  it('requests one fresh signed url before giving up on a live report route', async () => {
+    const getReport = vi.fn(async () => buildDetail('https://example.com/refreshed.jpg'))
+    const reportsClient = buildReportsClient({ getReport })
+
+    renderWithRoute(<RecordMedia record={baseRecord} />, {
+      initialEntries: ['/reports/report-123'],
+      reportsClient,
+      routePath: '/reports/:reportId',
+    })
+
+    fireEvent.error(screen.getByRole('img', { name: /Orphan Barrel Fanged Pursuit/i }))
+
+    await waitFor(() => {
+      expect(getReport).toHaveBeenCalledWith('report-123')
+      expect(screen.getByRole('img', { name: /Orphan Barrel Fanged Pursuit/i })).toHaveAttribute(
+        'src',
+        'https://example.com/refreshed.jpg',
+      )
+    })
+  })
+})
+
+describe('ProcessingRecord', () => {
+  it('falls back to the processing placeholder when an image request fails', () => {
+    renderWithRoute(<ProcessingRecord record={baseRecord} />, {
+      initialEntries: ['/reports/report-123'],
+      routePath: '/reports/:reportId',
+    })
+
+    fireEvent.error(screen.getByRole('img', { name: /Orphan Barrel Fanged Pursuit/i }))
+
+    expect(screen.getByText('◻')).toBeInTheDocument()
+    expect(screen.queryByRole('img', { name: /Orphan Barrel Fanged Pursuit/i })).not.toBeInTheDocument()
+  })
+})
+
+function renderWithRoute(
+  element: ReactNode,
+  {
+    initialEntries,
+    reportsClient,
+    routePath,
+  }: {
+    initialEntries: string[]
+    reportsClient?: ReportsClient
+    routePath: string
+  },
+) {
+  const router = createMemoryRouter([{ path: routePath, element }], { initialEntries })
+
+  return render(
+    <AppProviders reportsClient={reportsClient}>
+      <RouterProvider router={router} />
+    </AppProviders>,
+  )
+}
+
+function buildReportsClient(overrides?: Partial<ReportsClient>): ReportsClient {
+  const client = createFixtureReportsClient()
+
+  return {
+    ...client,
+    ...overrides,
+  }
+}
+
+function buildDetail(imageUrl: string): ReportDetail {
+  return {
+    id: 'report-123',
+    status: 'unreviewed',
+    bottleRecords: [{ ...baseRecord, imageUrl }],
+  }
+}

--- a/packages/dashboard/src/features/reports/components/report-record-media.test.tsx
+++ b/packages/dashboard/src/features/reports/components/report-record-media.test.tsx
@@ -21,6 +21,20 @@ const baseRecord: ReportBottleRecord = {
 }
 
 describe('RecordMedia', () => {
+  it('opens the full image in a new tab when media is available', () => {
+    renderWithRoute(<RecordMedia record={baseRecord} />, {
+      initialEntries: ['/reports/report-123'],
+      routePath: '/reports/:reportId',
+    })
+
+    expect(
+      screen.getByRole('link', { name: /Open Orphan Barrel Fanged Pursuit image in a new tab/i }),
+    ).toHaveAttribute('href', 'https://example.com/original.jpg')
+    expect(
+      screen.getByRole('link', { name: /Open Orphan Barrel Fanged Pursuit image in a new tab/i }),
+    ).toHaveAttribute('target', '_blank')
+  })
+
   it('shows the calm fallback when the image request fails outside a live report route', () => {
     renderWithRoute(<RecordMedia record={baseRecord} />, {
       initialEntries: ['/__review/report/unreviewed'],
@@ -56,6 +70,17 @@ describe('RecordMedia', () => {
 })
 
 describe('ProcessingRecord', () => {
+  it('opens the full image in a new tab when media is available', () => {
+    renderWithRoute(<ProcessingRecord record={baseRecord} />, {
+      initialEntries: ['/reports/report-123'],
+      routePath: '/reports/:reportId',
+    })
+
+    expect(
+      screen.getByRole('link', { name: /Open Orphan Barrel Fanged Pursuit image in a new tab/i }),
+    ).toHaveAttribute('href', 'https://example.com/original.jpg')
+  })
+
   it('falls back to the processing placeholder when an image request fails', () => {
     renderWithRoute(<ProcessingRecord record={baseRecord} />, {
       initialEntries: ['/reports/report-123'],

--- a/packages/dashboard/src/features/reports/components/report-record-media.tsx
+++ b/packages/dashboard/src/features/reports/components/report-record-media.tsx
@@ -22,13 +22,22 @@ function ResolvedRecordMedia({ record }: { record: ReportBottleRecord }) {
 
   return (
     <div className="bt-record-media">
-      <img
-        alt={record.bottleName}
-        height={96}
-        onError={handleError}
-        src={imageUrl}
-        width={72}
-      />
+      <a
+        aria-label={`Open ${record.bottleName} image in a new tab`}
+        className="bt-record-media__link"
+        href={imageUrl}
+        rel="noopener noreferrer"
+        target="_blank"
+        title="Open full image in a new tab"
+      >
+        <img
+          alt={record.bottleName}
+          height={96}
+          onError={handleError}
+          src={imageUrl}
+          width={72}
+        />
+      </a>
     </div>
   )
 }

--- a/packages/dashboard/src/features/reports/components/report-record-media.tsx
+++ b/packages/dashboard/src/features/reports/components/report-record-media.tsx
@@ -1,7 +1,17 @@
 import type { ReportBottleRecord } from '@bartools/types'
+import {
+  getReportRecordImageStateKey,
+  useReportRecordImage,
+} from './use-report-record-image'
 
 export function RecordMedia({ record }: { record: ReportBottleRecord }) {
-  if (!record.imageUrl) {
+  return <ResolvedRecordMedia key={getReportRecordImageStateKey(record)} record={record} />
+}
+
+function ResolvedRecordMedia({ record }: { record: ReportBottleRecord }) {
+  const { handleError, imageUrl, showFallback } = useReportRecordImage(record)
+
+  if (showFallback) {
     return (
       <div className="bt-record-media bt-record-media--missing">
         <span aria-hidden="true">⌁</span>
@@ -12,7 +22,13 @@ export function RecordMedia({ record }: { record: ReportBottleRecord }) {
 
   return (
     <div className="bt-record-media">
-      <img alt={record.bottleName} height={96} src={record.imageUrl} width={72} />
+      <img
+        alt={record.bottleName}
+        height={96}
+        onError={handleError}
+        src={imageUrl}
+        width={72}
+      />
     </div>
   )
 }

--- a/packages/dashboard/src/features/reports/components/reports-empty-screen.tsx
+++ b/packages/dashboard/src/features/reports/components/reports-empty-screen.tsx
@@ -1,7 +1,11 @@
 import { Button } from '../../../components/primitives/button'
 import { SurfaceCard } from '../../../components/primitives/surface-card'
 
-export function ReportsEmptyScreen() {
+export function ReportsEmptyScreen({
+  showBackstockAction,
+}: {
+  showBackstockAction: boolean
+}) {
   return (
     <div className="bt-reports-empty">
       <SurfaceCard className="bt-empty-state" tone="low">
@@ -12,11 +16,13 @@ export function ReportsEmptyScreen() {
         <p className="bt-empty-state__body">
           No reports found. Recent reports will appear here once they are available.
         </p>
-        <div className="bt-loading-panel__actions">
-          <Button to="/reports/backstock/new" variant="secondary">
-            New Backstock Report
-          </Button>
-        </div>
+        {showBackstockAction ? (
+          <div className="bt-loading-panel__actions">
+            <Button to="/reports/backstock/new" variant="secondary">
+              New Backstock Report
+            </Button>
+          </div>
+        ) : null}
       </SurfaceCard>
     </div>
   )

--- a/packages/dashboard/src/features/reports/components/reports-list-header.tsx
+++ b/packages/dashboard/src/features/reports/components/reports-list-header.tsx
@@ -1,6 +1,10 @@
 import { Button } from '../../../components/primitives/button'
 
-export function ReportsListHeader() {
+export function ReportsListHeader({
+  showBackstockAction,
+}: {
+  showBackstockAction: boolean
+}) {
   return (
     <section className="bt-reports-header">
       <div className="bt-reports-header__copy">
@@ -9,9 +13,11 @@ export function ReportsListHeader() {
           Review recent reports and open one to inspect records.
         </p>
       </div>
-      <Button to="/reports/backstock/new" variant="secondary">
-        New Backstock Report
-      </Button>
+      {showBackstockAction ? (
+        <Button to="/reports/backstock/new" variant="secondary">
+          New Backstock Report
+        </Button>
+      ) : null}
     </section>
   )
 }

--- a/packages/dashboard/src/features/reports/components/reports-list-screen.tsx
+++ b/packages/dashboard/src/features/reports/components/reports-list-screen.tsx
@@ -10,18 +10,20 @@ type ReportsListScreenProps = {
   errorMessage?: string | null
   onRetry?: () => void
   reports: ReportListItem[] | null
+  showBackstockAction?: boolean
 }
 
 export function ReportsListScreen({
   errorMessage = null,
   onRetry,
   reports,
+  showBackstockAction = true,
 }: ReportsListScreenProps) {
   const rows = reports ? buildReportListRows(reports) : []
 
   return (
     <div className="bt-reports-screen">
-      <ReportsListHeader />
+      <ReportsListHeader showBackstockAction={showBackstockAction} />
 
       {errorMessage ? (
         <SurfaceCard className="bt-loading-panel" tone="low">
@@ -41,7 +43,7 @@ export function ReportsListScreen({
           <p className="bt-loading-panel__body">Loading recent reports.</p>
         </SurfaceCard>
       ) : rows.length === 0 ? (
-        <ReportsEmptyScreen />
+        <ReportsEmptyScreen showBackstockAction={showBackstockAction} />
       ) : (
         <section className="bt-reports-list">
           <div className="bt-reports-columns" aria-hidden="true">

--- a/packages/dashboard/src/features/reports/components/use-report-record-image.ts
+++ b/packages/dashboard/src/features/reports/components/use-report-record-image.ts
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import type { ReportBottleRecord } from '@bartools/types'
+import { useParams } from 'react-router-dom'
+import { useReportsClient } from '../../../lib/reports/provider'
+
+export function getReportRecordImageStateKey(record: ReportBottleRecord) {
+  return `${record.id}:${record.imageUrl}`
+}
+
+export function useReportRecordImage(record: ReportBottleRecord) {
+  const client = useReportsClient()
+  const { reportId } = useParams()
+  const [imageUrl, setImageUrl] = useState(record.imageUrl)
+  const [loadFailed, setLoadFailed] = useState(!record.imageUrl)
+  const [refreshAttempted, setRefreshAttempted] = useState(false)
+
+  const handleError = () => {
+    setLoadFailed(true)
+
+    if (!imageUrl || !reportId || refreshAttempted) {
+      return
+    }
+
+    setRefreshAttempted(true)
+
+    void client
+      .getReport(reportId)
+      .then((detail) => detail?.bottleRecords.find((nextRecord) => nextRecord.id === record.id) ?? null)
+      .then((nextRecord) => {
+        if (!nextRecord?.imageUrl) {
+          return
+        }
+
+        setImageUrl(nextRecord.imageUrl)
+        setLoadFailed(false)
+      })
+      .catch(() => undefined)
+  }
+
+  return {
+    imageUrl,
+    showFallback: loadFailed || !imageUrl,
+    handleError,
+  }
+}

--- a/packages/dashboard/src/features/reports/reports-workbench.css
+++ b/packages/dashboard/src/features/reports/reports-workbench.css
@@ -1,6 +1,7 @@
 @import './styles/workbench-foundation.css';
 @import './styles/reports-list.css';
 @import './styles/report-detail.css';
+@import './styles/report-comparison-card.css';
 @import './styles/report-review-action.css';
 @import './styles/report-states-responsive.css';
 @import '../backstock/styles/backstock-report.css';

--- a/packages/dashboard/src/features/reports/reports-workbench.css
+++ b/packages/dashboard/src/features/reports/reports-workbench.css
@@ -2,6 +2,7 @@
 @import './styles/reports-list.css';
 @import './styles/report-detail.css';
 @import './styles/report-comparison-card.css';
+@import './styles/report-record-media.css';
 @import './styles/report-review-action.css';
 @import './styles/report-states-responsive.css';
 @import '../backstock/styles/backstock-report.css';

--- a/packages/dashboard/src/features/reports/routes/reports-route.test.tsx
+++ b/packages/dashboard/src/features/reports/routes/reports-route.test.tsx
@@ -30,6 +30,7 @@ describe('Reports workbench routes: baseline states', () => {
     expect(await screen.findByRole('heading', { name: 'Campari' })).toBeInTheDocument()
     expect(await screen.findByText('Original Model Output')).toBeInTheDocument()
     expect(screen.getByText('Final Corrected Values')).toBeInTheDocument()
+    expect(screen.getByText('Image unavailable')).toBeInTheDocument()
   })
 
   it('shows corrected comparison labels on reviewed reports', async () => {
@@ -37,6 +38,7 @@ describe('Reports workbench routes: baseline states', () => {
       initialEntries: ['/reports/report-1003'],
     })
 
+    expect(await screen.findByRole('img', { name: /Tito's Handmade Vodka/i })).toBeInTheDocument()
     expect((await screen.findAllByText('Original Model Output')).length).toBeGreaterThan(0)
     expect(screen.getAllByText('Final Corrected Values').length).toBeGreaterThan(0)
   })

--- a/packages/dashboard/src/features/reports/routes/reports-route.test.tsx
+++ b/packages/dashboard/src/features/reports/routes/reports-route.test.tsx
@@ -143,6 +143,47 @@ describe('Reports workbench routes: resilience', () => {
     expect(listReports).toHaveBeenCalledTimes(2)
   })
 
+  it('hides the backstock shortcut on the live reports list', async () => {
+    const baseClient = createFixtureReportsClient()
+
+    renderAppRoutes({
+      initialEntries: ['/reports'],
+      reportsClient: {
+        ...baseClient,
+        readiness: {
+          backendEnabled: true,
+          blockedReason: 'none' as const,
+          message: 'Live reports are connected.',
+        },
+      },
+    })
+
+    expect(await screen.findByText('created')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'New Backstock Report' })).not.toBeInTheDocument()
+  })
+
+  it('hides the backstock shortcut on the live empty state', async () => {
+    const baseClient = createFixtureReportsClient()
+
+    renderAppRoutes({
+      initialEntries: ['/reports'],
+      reportsClient: {
+        ...baseClient,
+        async listReports() {
+          return []
+        },
+        readiness: {
+          backendEnabled: true,
+          blockedReason: 'none' as const,
+          message: 'Live reports are connected.',
+        },
+      },
+    })
+
+    expect(await screen.findByText('No reports found. Recent reports will appear here once they are available.')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'New Backstock Report' })).not.toBeInTheDocument()
+  })
+
   it('shows a calm report unavailable state when report detail fails to load', async () => {
     const baseClient = createFixtureReportsClient()
     const user = userEvent.setup()

--- a/packages/dashboard/src/features/reports/routes/reports-route.tsx
+++ b/packages/dashboard/src/features/reports/routes/reports-route.tsx
@@ -14,6 +14,7 @@ export function ReportsRoute() {
   const { loadResult } = useLoaderData() as ReportsListRouteData
   const client = useReportsClient()
   const revalidator = useRevalidator()
+  const showBackstockAction = !client.readiness.backendEnabled
 
   useEffect(() => {
     if (!client.readiness.backendEnabled) {
@@ -39,12 +40,17 @@ export function ReportsRoute() {
     <Suspense
       fallback={
         <DelayedFallback>
-          <ReportsListScreen reports={null} />
+          <ReportsListScreen reports={null} showBackstockAction={showBackstockAction} />
         </DelayedFallback>
       }
     >
       <Await resolve={loadResult}>
-        {(result: ReportsListLoadResult) => <ResolvedReportsRoute loadResult={result} />}
+        {(result: ReportsListLoadResult) => (
+          <ResolvedReportsRoute
+            loadResult={result}
+            showBackstockAction={showBackstockAction}
+          />
+        )}
       </Await>
     </Suspense>
   )
@@ -52,8 +58,10 @@ export function ReportsRoute() {
 
 function ResolvedReportsRoute({
   loadResult,
+  showBackstockAction,
 }: {
   loadResult: ReportsListLoadResult
+  showBackstockAction: boolean
 }) {
   const revalidator = useRevalidator()
 
@@ -67,9 +75,15 @@ function ResolvedReportsRoute({
           })
         }}
         reports={null}
+        showBackstockAction={showBackstockAction}
       />
     )
   }
 
-  return <ReportsListScreen reports={loadResult.reports} />
+  return (
+    <ReportsListScreen
+      reports={loadResult.reports}
+      showBackstockAction={showBackstockAction}
+    />
+  )
 }

--- a/packages/dashboard/src/features/reports/styles/report-comparison-card.css
+++ b/packages/dashboard/src/features/reports/styles/report-comparison-card.css
@@ -14,6 +14,10 @@
   height: 150px;
 }
 
+.bt-comparison-card:not(.bt-comparison-card--hero) .bt-comparison-card__media .bt-record-media img {
+  object-fit: cover;
+}
+
 .bt-comparison-card__hero-header {
   align-items: center;
 }

--- a/packages/dashboard/src/features/reports/styles/report-comparison-card.css
+++ b/packages/dashboard/src/features/reports/styles/report-comparison-card.css
@@ -1,0 +1,15 @@
+.bt-comparison-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-lg);
+}
+
+.bt-comparison-card__media {
+  flex: 0 0 auto;
+}
+
+.bt-comparison-card__media .bt-record-media,
+.bt-comparison-card__media .bt-record-media--missing {
+  width: 52px;
+  height: 68px;
+}

--- a/packages/dashboard/src/features/reports/styles/report-comparison-card.css
+++ b/packages/dashboard/src/features/reports/styles/report-comparison-card.css
@@ -1,6 +1,6 @@
 .bt-comparison-card__header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--space-lg);
 }
 
@@ -10,6 +10,16 @@
 
 .bt-comparison-card__media .bt-record-media,
 .bt-comparison-card__media .bt-record-media--missing {
+  width: 112px;
+  height: 150px;
+}
+
+.bt-comparison-card__hero-header {
+  align-items: center;
+}
+
+.bt-comparison-card__hero-header .bt-comparison-card__media .bt-record-media,
+.bt-comparison-card__hero-header .bt-comparison-card__media .bt-record-media--missing {
   width: 52px;
   height: 68px;
 }

--- a/packages/dashboard/src/features/reports/styles/report-record-media.css
+++ b/packages/dashboard/src/features/reports/styles/report-record-media.css
@@ -1,0 +1,21 @@
+.bt-record-media__link,
+.bt-processing-record__media-link {
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: zoom-in;
+  border-radius: inherit;
+}
+
+.bt-record-media__link:focus-visible,
+.bt-processing-record__media-link:focus-visible {
+  outline: 1px solid var(--color-accent-soft);
+  outline-offset: 2px;
+}
+
+.bt-record-media__link:hover img,
+.bt-record-media__link:focus-visible img,
+.bt-processing-record__media-link:hover img,
+.bt-processing-record__media-link:focus-visible img {
+  opacity: 1;
+}

--- a/packages/dashboard/src/features/reports/styles/report-record-media.css
+++ b/packages/dashboard/src/features/reports/styles/report-record-media.css
@@ -3,7 +3,7 @@
   display: block;
   width: 100%;
   height: 100%;
-  cursor: zoom-in;
+  cursor: pointer;
   border-radius: inherit;
 }
 

--- a/packages/dashboard/src/features/reports/styles/report-states-responsive.css
+++ b/packages/dashboard/src/features/reports/styles/report-states-responsive.css
@@ -87,21 +87,8 @@
 }
 
 .bt-comparison-card__hero-header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-lg);
   padding: var(--space-2xl);
   border-bottom: 1px solid var(--color-border-subtle);
-}
-
-.bt-comparison-card__hero-media {
-  flex: 0 0 auto;
-}
-
-.bt-comparison-card__hero-media .bt-record-media,
-.bt-comparison-card__hero-media .bt-record-media--missing {
-  width: 52px;
-  height: 68px;
 }
 
 .bt-processing-record__media img,

--- a/packages/dashboard/src/features/reports/styles/report-states-responsive.css
+++ b/packages/dashboard/src/features/reports/styles/report-states-responsive.css
@@ -98,7 +98,6 @@
   height: 100%;
   object-fit: contain;
   object-position: center;
-  padding: 8px;
   opacity: 0.82;
 }
 

--- a/packages/dashboard/src/lib/reports/backend-client.test.ts
+++ b/packages/dashboard/src/lib/reports/backend-client.test.ts
@@ -43,6 +43,25 @@ describe('backend reports client', () => {
     expect(detail?.bottleRecords[0]?.imageUrl).toBe('/api/reports/report-1002/records/record-1/image')
   })
 
+  it('keeps absolute image urls absolute when the dashboard api base is relative', async () => {
+    const imageUrl =
+      'https://storage.googleapis.com/bartools-uploads-staging/reports/report-1002/record-1.jpg?sig=demo'
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(
+        buildReportDetailResponse({
+          imageUrl,
+        }),
+      ),
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createBackendReportsClient({ baseUrl: '/api' })
+    const detail = await client.getReport('report-1002')
+
+    expect(detail?.bottleRecords[0]?.imageUrl).toBe(imageUrl)
+  })
+
   it('returns null for unknown reports and clears gs:// image urls for detail payloads', async () => {
     const fetchMock = vi
       .fn()

--- a/packages/dashboard/src/lib/reports/backend-client.ts
+++ b/packages/dashboard/src/lib/reports/backend-client.ts
@@ -338,6 +338,10 @@ function extractApiError(payload: unknown, status: number) {
 }
 
 function resolveApiUrl(baseUrl: string, path: string) {
+  if (isAbsoluteUrl(path)) {
+    return path
+  }
+
   if (isAbsoluteUrl(baseUrl)) {
     return new URL(path, `${baseUrl}/`).toString()
   }


### PR DESCRIPTION
## Summary
- hide the live backstock shortcut from reports surfaces when the backend path cannot finish
- keep the direct backstock route available, defaulting live mode to manual entry with photo-assisted disabled
- update route and UI tests to lock the live/manual behavior in place

## Validation
- bun --filter @bartools/dashboard lint
- bun --filter @bartools/dashboard typecheck
- bun --filter @bartools/dashboard test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Report images can now be opened in a new tab for full viewing
  * Enhanced image error handling with automatic refresh when images fail to load

* **Improvements**
  * Photo-assisted report generation can be conditionally disabled based on configuration
  * Better handling and display of missing or corrupted report media
  * Improved visual feedback for unavailable features and disabled controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->